### PR TITLE
Remove min & max requirement from Between constructor

### DIFF
--- a/src/Between.php
+++ b/src/Between.php
@@ -64,7 +64,13 @@ class Between extends AbstractValidator
         }
         if (!is_array($options)) {
             $options = func_get_args();
-            $temp['min'] = array_shift($options);
+
+            $temp = [];
+
+            if (!empty($options)) {
+                $temp['min'] = array_shift($options);
+            }
+
             if (!empty($options)) {
                 $temp['max'] = array_shift($options);
             }

--- a/src/Between.php
+++ b/src/Between.php
@@ -56,8 +56,6 @@ class Between extends AbstractValidator
      *   'inclusive' => boolean, inclusive border values
      *
      * @param  array|Traversable $options
-     *
-     * @throws Exception\InvalidArgumentException
      */
     public function __construct($options = null)
     {

--- a/src/Between.php
+++ b/src/Between.php
@@ -78,12 +78,6 @@ class Between extends AbstractValidator
             $options = $temp;
         }
 
-        if (count($options) !== 2
-            && (!array_key_exists('min', $options) || !array_key_exists('max', $options))
-        ) {
-            throw new Exception\InvalidArgumentException("Missing option. 'min' and 'max' have to be given");
-        }
-
         parent::__construct($options);
     }
 

--- a/test/BetweenTest.php
+++ b/test/BetweenTest.php
@@ -103,22 +103,6 @@ class BetweenTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeEquals($validator->getOption('messageVariables'), 'messageVariables', $validator);
     }
 
-    /**
-     * @covers Zend\Validator\Between::__construct()
-     * @dataProvider constructBetweenValidatorInvalidDataProvider
-     *
-     * @param array $args
-     */
-    public function testMissingMinOrMax(array $args)
-    {
-        $this->setExpectedException(
-            'Zend\Validator\Exception\InvalidArgumentException',
-            "Missing option. 'min' and 'max' have to be given"
-        );
-
-        new Between($args);
-    }
-
     public function constructBetweenValidatorInvalidDataProvider()
     {
         return [

--- a/test/BetweenTest.php
+++ b/test/BetweenTest.php
@@ -149,4 +149,22 @@ class BetweenTest extends \PHPUnit_Framework_TestCase
             );
         }
     }
+
+    public function testIsValidWithDefaultOptions()
+    {
+        $validator = new Between();
+
+        $this->assertTrue($validator->isValid(0));
+        $this->assertTrue($validator->isValid(PHP_INT_MAX));
+
+        $validator = new Between(['inclusive' => false]);
+
+        $this->assertFalse($validator->isValid(0));
+        $this->assertFalse($validator->isValid(PHP_INT_MAX));
+
+        $validator = new Between(1, 10000);
+        
+        $this->assertFalse($validator->isValid(0));
+        $this->assertFalse($validator->isValid(PHP_INT_MAX));
+    }
 }

--- a/test/BetweenTest.php
+++ b/test/BetweenTest.php
@@ -108,8 +108,29 @@ class BetweenTest extends \PHPUnit_Framework_TestCase
      */
     public function testUsingDefaultValues()
     {
+        $defaults = [
+            'min' => 0,
+            'max' => PHP_INT_MAX,
+            'inclusive' => true
+        ];
+
+        $validator = new Between();
+
+        $this->assertSame($defaults['min'], $validator->getMin());
+        $this->assertSame($defaults['max'], $validator->getMax());
+        $this->assertSame($defaults['inclusive'], $validator->getInclusive());
+
+        $this->assertAttributeEquals(
+            [
+                'min' => $defaults['min'],
+                'max' => $defaults['max'],
+                'inclusive' => $defaults['inclusive']
+            ],
+            'options',
+            $validator
+        );
+
         $optionSets = [
-            null,
             ['min' => 25],
             ['max' => 50],
             ['inclusive' => false],
@@ -117,12 +138,6 @@ class BetweenTest extends \PHPUnit_Framework_TestCase
             ['min' => 25, 'inclusive' => false],
             ['max' => 50, 'inclusive' => false],
             ['min' => 25, 'max' => 50, 'inclusive' => false]
-        ];
-
-        $defaults = [
-            'min' => 0,
-            'max' => PHP_INT_MAX,
-            'inclusive' => true
         ];
 
         foreach ($optionSets as $options) {
@@ -134,9 +149,9 @@ class BetweenTest extends \PHPUnit_Framework_TestCase
 
             $validator = new Between($options);
 
-            $this->assertEquals($expected['min'], $validator->getMin());
-            $this->assertEquals($expected['max'], $validator->getMax());
-            $this->assertEquals($expected['inclusive'], $validator->getInclusive());
+            $this->assertSame($expected['min'], $validator->getMin());
+            $this->assertSame($expected['max'], $validator->getMax());
+            $this->assertSame($expected['inclusive'], $validator->getInclusive());
 
             $this->assertAttributeEquals(
                 [
@@ -153,7 +168,10 @@ class BetweenTest extends \PHPUnit_Framework_TestCase
     public function testIsValidWithDefaultOptions()
     {
         $validator = new Between();
+        $this->assertSame(0, $validator->getMin());
+        $this->assertSame(PHP_INT_MAX, $validator->getMax());
 
+        $this->assertFalse($validator->isValid((int) -1));
         $this->assertTrue($validator->isValid(0));
         $this->assertTrue($validator->isValid(PHP_INT_MAX));
 

--- a/test/BetweenTest.php
+++ b/test/BetweenTest.php
@@ -103,15 +103,50 @@ class BetweenTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeEquals($validator->getOption('messageVariables'), 'messageVariables', $validator);
     }
 
-    public function constructBetweenValidatorInvalidDataProvider()
+    /**
+     * Tests default options are correct with different
+     */
+    public function testUsingDefaultValues()
     {
-        return [
-            [
-                ['min' => 1],
-            ],
-            [
-                ['max' => 5],
-            ],
+        $optionSets = [
+            null,
+            ['min' => 25],
+            ['max' => 50],
+            ['inclusive' => false],
+            ['min' => 25, 'max' => 50],
+            ['min' => 25, 'inclusive' => false],
+            ['max' => 50, 'inclusive' => false],
+            ['min' => 25, 'max' => 50, 'inclusive' => false]
         ];
+
+        $defaults = [
+            'min' => 0,
+            'max' => PHP_INT_MAX,
+            'inclusive' => true
+        ];
+
+        foreach ($optionSets as $options) {
+            if (!is_array($options)) {
+                $expected = $defaults;
+            } else {
+                $expected = array_merge($defaults, $options);
+            }
+
+            $validator = new Between($options);
+
+            $this->assertEquals($expected['min'], $validator->getMin());
+            $this->assertEquals($expected['max'], $validator->getMax());
+            $this->assertEquals($expected['inclusive'], $validator->getInclusive());
+
+            $this->assertAttributeEquals(
+                [
+                    'min' => $expected['min'],
+                    'max' => $expected['max'],
+                    'inclusive' => $expected['inclusive']
+                ],
+                'options',
+                $validator
+            );
+        }
     }
 }

--- a/test/BetweenTest.php
+++ b/test/BetweenTest.php
@@ -163,7 +163,7 @@ class BetweenTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($validator->isValid(PHP_INT_MAX));
 
         $validator = new Between(1, 10000);
-        
+
         $this->assertFalse($validator->isValid(0));
         $this->assertFalse($validator->isValid(PHP_INT_MAX));
     }


### PR DESCRIPTION
 * Allows to be instantiated using default min and max values