### PR TITLE
[NotEmpty] 0.0 should be treated as non empty by default

### DIFF
--- a/src/NotEmpty.php
+++ b/src/NotEmpty.php
@@ -48,7 +48,7 @@ class NotEmpty extends AbstractValidator
     ];
 
     /**
-     * Default value for types; value = 493
+     * Default value for types; value = 0b000111101001
      *
      * @var array
      */
@@ -58,7 +58,6 @@ class NotEmpty extends AbstractValidator
         self::NULL,
         self::EMPTY_ARRAY,
         self::STRING,
-        self::FLOAT,
         self::BOOLEAN
     ];
 

--- a/test/NotEmptyTest.php
+++ b/test/NotEmptyTest.php
@@ -65,7 +65,7 @@ class NotEmptyTest extends \PHPUnit_Framework_TestCase
             [null, false],
             [[], false],
             [[5], true],
-            [0.0, false],
+            [0.0, true],
             [1.0, true],
             [new stdClass(), true],
         ];
@@ -975,7 +975,6 @@ class NotEmptyTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertSame(
             NotEmpty::BOOLEAN
-                | NotEmpty::FLOAT
                 | NotEmpty::STRING
                 | NotEmpty::EMPTY_ARRAY
                 | NotEmpty::NULL


### PR DESCRIPTION
Following the reasoning of allow `0` as non empty then `0.0` should be too.

http://framework.zend.com/issues/browse/ZF-6708

This makes the input filter to have a different behavior for 0.0