### PR TITLE
Complete zend-servicemanager v2+v3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,21 +24,21 @@ matrix:
         - EXECUTE_HOSTNAME_CHECK=true
     - php: 5.5
       env:
-        - SERVICE_MANAGER_V2=true
+        - SERVICE_MANAGER_VERSION="^2.7.5"
     - php: 5.6
       env:
         - EXECUTE_TEST_COVERALLS=true
     - php: 5.6
       env:
-        - SERVICE_MANAGER_V2=true
+        - SERVICE_MANAGER_VERSION="^2.7.5"
     - php: 7
     - php: 7
       env:
-        - SERVICE_MANAGER_V2=true
+        - SERVICE_MANAGER_VERSION="^2.7.5"
     - php: hhvm 
     - php: hhvm 
       env:
-        - SERVICE_MANAGER_V2=true
+        - SERVICE_MANAGER_VERSION="^2.7.5"
   allow_failures:
     - php: hhvm
 
@@ -50,8 +50,9 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
   - composer self-update
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
-  - if [[ $SERVICE_MANAGER_V2 == 'true' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^2.7.2" ; fi
-  - if [[ $SERVICE_MANAGER_V2 != 'true' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0" ; fi
+  - if [[ $SERVICE_MANAGER_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:$SERVICE_MANAGER_VERSION" ; fi
+  - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0.3" ; fi
+  - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer remove --dev --no-update zendframework/zend-db zendframework/zend-session ; fi
 
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,23 @@ matrix:
       env:
         - EXECUTE_CS_CHECK=true
         - EXECUTE_HOSTNAME_CHECK=true
+    - php: 5.5
+      env:
+        - SERVICE_MANAGER_V2=true
     - php: 5.6
       env:
         - EXECUTE_TEST_COVERALLS=true
+    - php: 5.6
+      env:
+        - SERVICE_MANAGER_V2=true
     - php: 7
+    - php: 7
+      env:
+        - SERVICE_MANAGER_V2=true
     - php: hhvm 
+    - php: hhvm 
+      env:
+        - SERVICE_MANAGER_V2=true
   allow_failures:
     - php: hhvm
 
@@ -38,6 +50,8 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
   - composer self-update
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
+  - if [[ $SERVICE_MANAGER_V2 == 'true' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^2.7.2" ; fi
+  - if [[ $SERVICE_MANAGER_V2 != 'true' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0" ; fi
 
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,12 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
+- [#45](https://github.com/zendframework/zend-validator/pull/45) fixes aliases
+  mapping the deprecated `Float` and `Int` validators to their `Is*` counterparts.
 - [#49](https://github.com/zendframework/zend-validator/pull/49) updates the
   code to work with the upcoming zend-servicemanager v3.
+- [#56](https://github.com/zendframework/zend-validator/pull/56) fixes the regex
+  in the `Ip` validator to escape `.` characters used as IP delimiters.
 
 ## 2.5.5 - TBD
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "zendframework/zend-http": "~2.5",
         "zendframework/zend-i18n": "dev-develop as 2.6.0",
         "zendframework/zend-math": "dev-develop as 2.6.0",
-        "zendframework/zend-servicemanager": "dev-develop as 2.7.0",
+        "zendframework/zend-servicemanager": "^2.7.2 || ^3.0",
         "zendframework/zend-session": "dev-develop as 2.6.0",
         "zendframework/zend-uri": "~2.5",
         "fabpot/php-cs-fixer": "1.7.*",

--- a/composer.json
+++ b/composer.json
@@ -18,18 +18,18 @@
         "container-interop/container-interop": "^1.1"
     },
     "require-dev": {
-        "zendframework/zend-cache": "dev-develop as 2.6.0",
+        "zendframework/zend-cache": "^2.6.1",
         "zendframework/zend-config": "^2.6",
-        "zendframework/zend-db": "dev-develop as 2.7.0",
+        "zendframework/zend-db": "^2.5",
         "zendframework/zend-filter": "^2.6",
-        "zendframework/zend-http": "^2.5",
-        "zendframework/zend-i18n": "dev-develop as 2.6.0",
+        "zendframework/zend-http": "^2.5.4",
+        "zendframework/zend-i18n": "^2.6",
         "zendframework/zend-math": "^2.6",
         "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
-        "zendframework/zend-session": "dev-develop as 2.6.0",
+        "zendframework/zend-session": "^2.5",
         "zendframework/zend-uri": "^2.5",
         "fabpot/php-cs-fixer": "1.7.*",
-        "phpunit/PHPUnit": "~4.0"
+        "phpunit/PHPUnit": "^4.0"
     },
     "suggest": {
         "zendframework/zend-db": "Zend\\Db component",

--- a/composer.json
+++ b/composer.json
@@ -14,20 +14,20 @@
     },
     "require": {
         "php": "^5.5 || ^7.0",
-        "zendframework/zend-stdlib": "dev-develop as 2.8.0",
+        "zendframework/zend-stdlib": "^2.7 || ^3.0",
         "container-interop/container-interop": "^1.1"
     },
     "require-dev": {
         "zendframework/zend-cache": "dev-develop as 2.6.0",
-        "zendframework/zend-config": "dev-develop as 2.6.0",
+        "zendframework/zend-config": "^2.6",
         "zendframework/zend-db": "dev-develop as 2.7.0",
-        "zendframework/zend-filter": "dev-develop as 2.6.0",
-        "zendframework/zend-http": "~2.5",
+        "zendframework/zend-filter": "^2.6",
+        "zendframework/zend-http": "^2.5",
         "zendframework/zend-i18n": "dev-develop as 2.6.0",
-        "zendframework/zend-math": "dev-develop as 2.6.0",
-        "zendframework/zend-servicemanager": "^2.7.2 || ^3.0",
+        "zendframework/zend-math": "^2.6",
+        "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
         "zendframework/zend-session": "dev-develop as 2.6.0",
-        "zendframework/zend-uri": "~2.5",
+        "zendframework/zend-uri": "^2.5",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"
     },

--- a/src/StaticValidator.php
+++ b/src/StaticValidator.php
@@ -28,7 +28,12 @@ class StaticValidator
     {
         // Don't share by default to allow different arguments on subsequent calls
         if ($plugins instanceof ValidatorPluginManager) {
-            $plugins->configure(['shared_by_default' => false]);
+            // Vary how the share by default flag is set based on zend-servicemanager version
+            if (method_exists($plugins, 'configure')) {
+                $plugins->configure(['shared_by_default' => false]);
+            } else {
+                $plugins->setShareByDefault(false);
+            }
         }
         static::$plugins = $plugins;
     }

--- a/src/ValidatorPluginManager.php
+++ b/src/ValidatorPluginManager.php
@@ -364,7 +364,14 @@ class ValidatorPluginManager extends AbstractPluginManager
     ];
 
     /**
-     * Whether or not to share by default; default to false
+     * Whether or not to share by default; default to false (v2)
+     *
+     * @var bool
+     */
+    protected $shareByDefault = false;
+
+    /**
+     * Whether or not to share by default; default to false (v3)
      *
      * @var bool
      */
@@ -383,14 +390,14 @@ class ValidatorPluginManager extends AbstractPluginManager
      * After invoking parent constructor, add an initializer to inject the
      * attached translator, if any, to the currently requested helper.
      *
-     * @param  ContainerInterface $parentLocator
-     * @param  array $config
+     * {@inheritDoc}
      */
-    public function __construct(ContainerInterface $parentLocator, array $config = [])
+    public function __construct($configOrContainerInstance = null, array $v3config = [])
     {
-        $config['initializers'][] = [$this, 'injectTranslator'];
-        $config['initializers'][] = [$this, 'injectValidatorPluginManager'];
-        parent::__construct($parentLocator, $config);
+        parent::__construct($configOrContainerInstance, $v3config);
+
+        $this->addInitializer([$this, 'injectTranslator']);
+        $this->addInitializer([$this, 'injectValidatorPluginManager']);
     }
 
     /**

--- a/src/ValidatorPluginManager.php
+++ b/src/ValidatorPluginManager.php
@@ -426,12 +426,19 @@ class ValidatorPluginManager extends AbstractPluginManager
     /**
      * Inject a validator instance with the registered translator
      *
-     * @param  ContainerInterface $locator
-     * @param  ValidatorInterface $validator
+     * @param  ContainerInterface|object $first
+     * @param  ContainerInterface|object $second
      * @return void
      */
-    public function injectTranslator(ContainerInterface $locator, $validator)
+    public function injectTranslator($first, $second)
     {
+        if ($first instanceof ContainerInterface) {
+            $locator   = $first;
+            $validator = $second;
+        } else {
+            $locator   = $second;
+            $validator = $first;
+        }
         if ($validator instanceof Translator\TranslatorAwareInterface) {
             if ($locator && $locator->has('MvcTranslator')) {
                 $validator->setTranslator($locator->get('MvcTranslator'));
@@ -442,12 +449,19 @@ class ValidatorPluginManager extends AbstractPluginManager
     /**
      * Inject a validator plugin manager
      *
-     * @param  ContainerInterface $locator
-     * @param  $validator
+     * @param  ContainerInterface|object $first
+     * @param  ContainerInterface|object $second
      * @return void
      */
-    public function injectValidatorPluginManager(ContainerInterface $locator, $validator)
+    public function injectValidatorPluginManager($first, $second)
     {
+        if ($first instanceof ContainerInterface) {
+            $locator   = $first;
+            $validator = $second;
+        } else {
+            $locator   = $second;
+            $validator = $first;
+        }
         if ($validator instanceof ValidatorPluginManagerAwareInterface) {
             $validator->setValidatorPluginManager($this);
         }

--- a/src/ValidatorPluginManager.php
+++ b/src/ValidatorPluginManager.php
@@ -27,87 +27,6 @@ class ValidatorPluginManager extends AbstractPluginManager
         'Alnum'                    => I18nValidator\Alnum::class,
         'alpha'                    => I18nValidator\Alpha::class,
         'Alpha'                    => I18nValidator\Alpha::class,
-        'barcodecode25interleaved' => Barcode\Code25interleaved::class,
-        'barcodeCode25interleaved' => Barcode\Code25interleaved::class,
-        'BarcodeCode25interleaved' => Barcode\Code25interleaved::class,
-        'barcodecode25'            => Barcode\Code25::class,
-        'barcodeCode25'            => Barcode\Code25::class,
-        'BarcodeCode25'            => Barcode\Code25::class,
-        'barcodecode39ext'         => Barcode\Code39ext::class,
-        'barcodeCode39ext'         => Barcode\Code39ext::class,
-        'BarcodeCode39ext'         => Barcode\Code39ext::class,
-        'barcodecode39'            => Barcode\Code39::class,
-        'barcodeCode39'            => Barcode\Code39::class,
-        'BarcodeCode39'            => Barcode\Code39::class,
-        'barcodecode93ext'         => Barcode\Code93ext::class,
-        'barcodeCode93ext'         => Barcode\Code93ext::class,
-        'BarcodeCode93ext'         => Barcode\Code93ext::class,
-        'barcodecode93'            => Barcode\Code93::class,
-        'barcodeCode93'            => Barcode\Code93::class,
-        'BarcodeCode93'            => Barcode\Code93::class,
-        'barcodeean12'             => Barcode\Ean12::class,
-        'barcodeEan12'             => Barcode\Ean12::class,
-        'BarcodeEan12'             => Barcode\Ean12::class,
-        'barcodeean13'             => Barcode\Ean13::class,
-        'barcodeEan13'             => Barcode\Ean13::class,
-        'BarcodeEan13'             => Barcode\Ean13::class,
-        'barcodeean14'             => Barcode\Ean14::class,
-        'barcodeEan14'             => Barcode\Ean14::class,
-        'BarcodeEan14'             => Barcode\Ean14::class,
-        'barcodeean18'             => Barcode\Ean18::class,
-        'barcodeEan18'             => Barcode\Ean18::class,
-        'BarcodeEan18'             => Barcode\Ean18::class,
-        'barcodeean2'              => Barcode\Ean2::class,
-        'barcodeEan2'              => Barcode\Ean2::class,
-        'BarcodeEan2'              => Barcode\Ean2::class,
-        'barcodeean5'              => Barcode\Ean5::class,
-        'barcodeEan5'              => Barcode\Ean5::class,
-        'BarcodeEan5'              => Barcode\Ean5::class,
-        'barcodeean8'              => Barcode\Ean8::class,
-        'barcodeEan8'              => Barcode\Ean8::class,
-        'BarcodeEan8'              => Barcode\Ean8::class,
-        'barcodegtin12'            => Barcode\Gtin12::class,
-        'barcodeGtin12'            => Barcode\Gtin12::class,
-        'BarcodeGtin12'            => Barcode\Gtin12::class,
-        'barcodegtin13'            => Barcode\Gtin13::class,
-        'barcodeGtin13'            => Barcode\Gtin13::class,
-        'BarcodeGtin13'            => Barcode\Gtin13::class,
-        'barcodegtin14'            => Barcode\Gtin14::class,
-        'barcodeGtin14'            => Barcode\Gtin14::class,
-        'BarcodeGtin14'            => Barcode\Gtin14::class,
-        'barcodeidentcode'         => Barcode\Identcode::class,
-        'barcodeIdentcode'         => Barcode\Identcode::class,
-        'BarcodeIdentcode'         => Barcode\Identcode::class,
-        'barcodeintelligentmail'   => Barcode\Intelligentmail::class,
-        'barcodeIntelligentmail'   => Barcode\Intelligentmail::class,
-        'BarcodeIntelligentmail'   => Barcode\Intelligentmail::class,
-        'barcodeissn'              => Barcode\Issn::class,
-        'barcodeIssn'              => Barcode\Issn::class,
-        'BarcodeIssn'              => Barcode\Issn::class,
-        'barcodeitf14'             => Barcode\Itf14::class,
-        'barcodeItf14'             => Barcode\Itf14::class,
-        'BarcodeItf14'             => Barcode\Itf14::class,
-        'barcodeleitcode'          => Barcode\Leitcode::class,
-        'barcodeleItcode'          => Barcode\Leitcode::class,
-        'BarcodeleItcode'          => Barcode\Leitcode::class,
-        'barcodeplanet'            => Barcode\Planet::class,
-        'barcodePlanet'            => Barcode\Planet::class,
-        'BarcodePlanet'            => Barcode\Planet::class,
-        'barcodepostnet'           => Barcode\Postnet::class,
-        'barcodePostnet'           => Barcode\Postnet::class,
-        'BarcodePostnet'           => Barcode\Postnet::class,
-        'barcoderoyalmail'         => Barcode\Royalmail::class,
-        'barcodeRoyalmail'         => Barcode\Royalmail::class,
-        'BarcodeRoyalmail'         => Barcode\Royalmail::class,
-        'barcodesscc'              => Barcode\Sscc::class,
-        'barcodeSscc'              => Barcode\Sscc::class,
-        'BarcodeSscc'              => Barcode\Sscc::class,
-        'barcodeupca'              => Barcode\Upca::class,
-        'barcodeUpca'              => Barcode\Upca::class,
-        'BarcodeUpca'              => Barcode\Upca::class,
-        'barcodeupce'              => Barcode\Upce::class,
-        'barcodeUpce'              => Barcode\Upce::class,
-        'BarcodeUpce'              => Barcode\Upce::class,
         'barcode'                  => Barcode::class,
         'Barcode'                  => Barcode::class,
         'between'                  => Between::class,
@@ -275,33 +194,6 @@ class ValidatorPluginManager extends AbstractPluginManager
     protected $factories = [
         I18nValidator\Alnum::class             => InvokableFactory::class,
         I18nValidator\Alpha::class             => InvokableFactory::class,
-        Barcode\Code25interleaved::class       => InvokableFactory::class,
-        Barcode\Code25::class                  => InvokableFactory::class,
-        Barcode\Code39ext::class               => InvokableFactory::class,
-        Barcode\Code39::class                  => InvokableFactory::class,
-        Barcode\Code93ext::class               => InvokableFactory::class,
-        Barcode\Code93::class                  => InvokableFactory::class,
-        Barcode\Ean12::class                   => InvokableFactory::class,
-        Barcode\Ean13::class                   => InvokableFactory::class,
-        Barcode\Ean14::class                   => InvokableFactory::class,
-        Barcode\Ean18::class                   => InvokableFactory::class,
-        Barcode\Ean2::class                    => InvokableFactory::class,
-        Barcode\Ean5::class                    => InvokableFactory::class,
-        Barcode\Ean8::class                    => InvokableFactory::class,
-        Barcode\Gtin12::class                  => InvokableFactory::class,
-        Barcode\Gtin13::class                  => InvokableFactory::class,
-        Barcode\Gtin14::class                  => InvokableFactory::class,
-        Barcode\Identcode::class               => InvokableFactory::class,
-        Barcode\Intelligentmail::class         => InvokableFactory::class,
-        Barcode\Issn::class                    => InvokableFactory::class,
-        Barcode\Itf14::class                   => InvokableFactory::class,
-        Barcode\Leitcode::class                => InvokableFactory::class,
-        Barcode\Planet::class                  => InvokableFactory::class,
-        Barcode\Postnet::class                 => InvokableFactory::class,
-        Barcode\Royalmail::class               => InvokableFactory::class,
-        Barcode\Sscc::class                    => InvokableFactory::class,
-        Barcode\Upca::class                    => InvokableFactory::class,
-        Barcode\Upce::class                    => InvokableFactory::class,
         Barcode::class                         => InvokableFactory::class,
         Between::class                         => InvokableFactory::class,
         Bitwise::class                         => InvokableFactory::class,
@@ -361,6 +253,97 @@ class ValidatorPluginManager extends AbstractPluginManager
         Step::class                            => InvokableFactory::class,
         Timezone::class                        => InvokableFactory::class,
         Uri::class                             => InvokableFactory::class,
+
+        // v2 canonical FQCNs
+
+        'zendvalidatorbarcodecode25interleaved' => InvokableFactory::class,
+        'zendvalidatorbarcodecode25'            => InvokableFactory::class,
+        'zendvalidatorbarcodecode39ext'         => InvokableFactory::class,
+        'zendvalidatorbarcodecode39'            => InvokableFactory::class,
+        'zendvalidatorbarcodecode93ext'         => InvokableFactory::class,
+        'zendvalidatorbarcodecode93'            => InvokableFactory::class,
+        'zendvalidatorbarcodeean12'             => InvokableFactory::class,
+        'zendvalidatorbarcodeean13'             => InvokableFactory::class,
+        'zendvalidatorbarcodeean14'             => InvokableFactory::class,
+        'zendvalidatorbarcodeean18'             => InvokableFactory::class,
+        'zendvalidatorbarcodeean2'              => InvokableFactory::class,
+        'zendvalidatorbarcodeean5'              => InvokableFactory::class,
+        'zendvalidatorbarcodeean8'              => InvokableFactory::class,
+        'zendvalidatorbarcodegtin12'            => InvokableFactory::class,
+        'zendvalidatorbarcodegtin13'            => InvokableFactory::class,
+        'zendvalidatorbarcodegtin14'            => InvokableFactory::class,
+        'zendvalidatorbarcodeidentcode'         => InvokableFactory::class,
+        'zendvalidatorbarcodeintelligentmail'   => InvokableFactory::class,
+        'zendvalidatorbarcodeissn'              => InvokableFactory::class,
+        'zendvalidatorbarcodeitf14'             => InvokableFactory::class,
+        'zendvalidatorbarcodeleitcode'          => InvokableFactory::class,
+        'zendvalidatorbarcodeplanet'            => InvokableFactory::class,
+        'zendvalidatorbarcodepostnet'           => InvokableFactory::class,
+        'zendvalidatorbarcoderoyalmail'         => InvokableFactory::class,
+        'zendvalidatorbarcodesscc'              => InvokableFactory::class,
+        'zendvalidatorbarcodeupca'              => InvokableFactory::class,
+        'zendvalidatorbarcodeupce'              => InvokableFactory::class,
+        'zendvalidatorbarcode'                  => InvokableFactory::class,
+        'zendvalidatorbetween'                  => InvokableFactory::class,
+        'zendvalidatorbitwise'                  => InvokableFactory::class,
+        'zendvalidatorcallback'                 => InvokableFactory::class,
+        'zendvalidatorcreditcard'               => InvokableFactory::class,
+        'zendvalidatorcsrf'                     => InvokableFactory::class,
+        'zendvalidatordatestep'                 => InvokableFactory::class,
+        'zendvalidatordate'                     => InvokableFactory::class,
+        'zendvalidatordbnorecordexists'         => InvokableFactory::class,
+        'zendvalidatordbrecordexists'           => InvokableFactory::class,
+        'zendvalidatordigits'                   => InvokableFactory::class,
+        'zendvalidatoremailaddress'             => InvokableFactory::class,
+        'zendvalidatorexplode'                  => InvokableFactory::class,
+        'zendvalidatorfilecount'                => InvokableFactory::class,
+        'zendvalidatorfilecrc32'                => InvokableFactory::class,
+        'zendvalidatorfileexcludeextension'     => InvokableFactory::class,
+        'zendvalidatorfileexcludemimetype'      => InvokableFactory::class,
+        'zendvalidatorfileexists'               => InvokableFactory::class,
+        'zendvalidatorfileextension'            => InvokableFactory::class,
+        'zendvalidatorfilefilessize'            => InvokableFactory::class,
+        'zendvalidatorfilehash'                 => InvokableFactory::class,
+        'zendvalidatorfileimagesize'            => InvokableFactory::class,
+        'zendvalidatorfileiscompressed'         => InvokableFactory::class,
+        'zendvalidatorfileisimage'              => InvokableFactory::class,
+        'zendvalidatorfilemd5'                  => InvokableFactory::class,
+        'zendvalidatorfilemimetype'             => InvokableFactory::class,
+        'zendvalidatorfilenotexists'            => InvokableFactory::class,
+        'zendvalidatorfilesha1'                 => InvokableFactory::class,
+        'zendvalidatorfilesize'                 => InvokableFactory::class,
+        'zendvalidatorfileupload'               => InvokableFactory::class,
+        'zendvalidatorfileuploadfile'           => InvokableFactory::class,
+        'zendvalidatorfilewordcount'            => InvokableFactory::class,
+        'zendvalidatorgreaterthan'              => InvokableFactory::class,
+        'zendvalidatorhex'                      => InvokableFactory::class,
+        'zendvalidatorhostname'                 => InvokableFactory::class,
+        'zendi18nvalidatoralnum'                => InvokableFactory::class,
+        'zendi18nvalidatoralpha'                => InvokableFactory::class,
+        'zendi18nvalidatordatetime'             => InvokableFactory::class,
+        'zendi18nvalidatorisfloat'              => InvokableFactory::class,
+        'zendi18nvalidatorisint'                => InvokableFactory::class,
+        'zendi18nvalidatorisfloat'              => InvokableFactory::class,
+        'zendi18nvalidatorisint'                => InvokableFactory::class,
+        'zendi18nvalidatorphonenumber'          => InvokableFactory::class,
+        'zendi18nvalidatorpostcode'             => InvokableFactory::class,
+        'zendvalidatoriban'                     => InvokableFactory::class,
+        'zendvalidatoridentical'                => InvokableFactory::class,
+        'zendvalidatorinarray'                  => InvokableFactory::class,
+        'zendvalidatorip'                       => InvokableFactory::class,
+        'zendvalidatorisbn'                     => InvokableFactory::class,
+        'zendvalidatorisinstanceof'             => InvokableFactory::class,
+        'zendvalidatorlessthan'                 => InvokableFactory::class,
+        'zendvalidatornotempty'                 => InvokableFactory::class,
+        'zendvalidatorregex'                    => InvokableFactory::class,
+        'zendvalidatorsitemapchangefreq'        => InvokableFactory::class,
+        'zendvalidatorsitemaplastmod'           => InvokableFactory::class,
+        'zendvalidatorsitemaploc'               => InvokableFactory::class,
+        'zendvalidatorsitemappriority'          => InvokableFactory::class,
+        'zendvalidatorstringlength'             => InvokableFactory::class,
+        'zendvalidatorstep'                     => InvokableFactory::class,
+        'zendvalidatortimezone'                 => InvokableFactory::class,
+        'zendvalidatoruri'                      => InvokableFactory::class,
     ];
 
     /**
@@ -405,14 +388,14 @@ class ValidatorPluginManager extends AbstractPluginManager
      *
      * {@inheritDoc}
      */
-    public function validate($instance)
+    public function validate($plugin)
     {
-        if (! $instance instanceof $this->instanceOf) {
+        if (! $plugin instanceof $this->instanceOf) {
             throw new InvalidServiceException(sprintf(
                 '%s expects only to create instances of %s; %s is invalid',
                 get_class($this),
                 $this->instanceOf,
-                (is_object($instance) ? get_class($instance) : gettype($instance))
+                (is_object($plugin) ? get_class($plugin) : gettype($plugin))
             ));
         }
     }
@@ -422,12 +405,20 @@ class ValidatorPluginManager extends AbstractPluginManager
      *
      * Proxies to `validate()`.
      *
-     * @param mixed $instance
-     * @throws InvalidServiceException
+     * @param mixed $plugin
+     * @throws Exception\RuntimeException
      */
-    public function validatePlugin($instance)
+    public function validatePlugin($plugin)
     {
-        $this->validate($instance);
+        try {
+            $this->validate($plugin);
+        } catch (InvalidServiceException $e) {
+            throw new Exception\RuntimeException(sprintf(
+                'Plugin of type %s is invalid; must implement %s',
+                (is_object($plugin) ? get_class($plugin) : gettype($plugin)),
+                ValidatorInterface::class
+            ), $e->getCode(), $e);
+        }
     }
 
     /**
@@ -440,15 +431,21 @@ class ValidatorPluginManager extends AbstractPluginManager
     public function injectTranslator($first, $second)
     {
         if ($first instanceof ContainerInterface) {
-            $locator   = $first;
+            $container = $first;
             $validator = $second;
         } else {
-            $locator   = $second;
+            $container = $second;
             $validator = $first;
         }
+
+        // V2 means we pull it from the parent container
+        if ($container === $this && method_exists($container, 'getServiceLocator') && $container->getServiceLocator()) {
+            $container = $container->getServiceLocator();
+        }
+
         if ($validator instanceof Translator\TranslatorAwareInterface) {
-            if ($locator && $locator->has('MvcTranslator')) {
-                $validator->setTranslator($locator->get('MvcTranslator'));
+            if ($container && $container->has('MvcTranslator')) {
+                $validator->setTranslator($container->get('MvcTranslator'));
             }
         }
     }
@@ -463,10 +460,10 @@ class ValidatorPluginManager extends AbstractPluginManager
     public function injectValidatorPluginManager($first, $second)
     {
         if ($first instanceof ContainerInterface) {
-            $locator   = $first;
+            $container = $first;
             $validator = $second;
         } else {
-            $locator   = $second;
+            $container = $second;
             $validator = $first;
         }
         if ($validator instanceof ValidatorPluginManagerAwareInterface) {

--- a/test/CsrfTest.php
+++ b/test/CsrfTest.php
@@ -28,6 +28,13 @@ class CsrfTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
+        if (! class_exists(Container::class)) {
+            $this->markTestSkipped(
+                'Skipping zend-session-related tests until the component is updated '
+                . ' to zend-servicemanager/zend-eventmanager v3'
+            );
+        }
+
         // Setup session handling
         $_SESSION = [];
         $sessionConfig = new StandardConfig([
@@ -42,6 +49,10 @@ class CsrfTest extends \PHPUnit_Framework_TestCase
 
     public function tearDown()
     {
+        if (! class_exists(Container::class)) {
+            return;
+        }
+
         $_SESSION = [];
         Container::setDefaultManager(null);
     }

--- a/test/Db/AbstractDbTest.php
+++ b/test/Db/AbstractDbTest.php
@@ -24,6 +24,13 @@ class AbstractDbTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
+        if (! class_exists('Zend\Db\Adapter\Adapter')) {
+            $this->markTestSkipped(
+                'Skipping zend-db-related tests until that component is updated '
+                . 'to zend-servicemanager/zend-eventmanager v3'
+            );
+        }
+
         $this->validator = new ConcreteDbValidator([
             'table' => 'table',
             'field' => 'field',

--- a/test/Db/NoRecordExistsTest.php
+++ b/test/Db/NoRecordExistsTest.php
@@ -18,6 +18,16 @@ use ArrayObject;
  */
 class NoRecordExistsTest extends \PHPUnit_Framework_TestCase
 {
+    public function setUp()
+    {
+        if (! class_exists('Zend\Db\Adapter\Adapter')) {
+            $this->markTestSkipped(
+                'Skipping zend-db-related tests until that component is updated '
+                . 'to zend-servicemanager/zend-eventmanager v3'
+            );
+        }
+    }
+
     /**
      * Return a Mock object for a Db result with rows
      *
@@ -121,8 +131,12 @@ class NoRecordExistsTest extends \PHPUnit_Framework_TestCase
      */
     public function testExcludeWithArray()
     {
-        $validator = new NoRecordExists('users', 'field1', ['field' => 'id', 'value' => 1],
-                                        $this->getMockHasResult());
+        $validator = new NoRecordExists(
+            'users',
+            'field1',
+            ['field' => 'id', 'value' => 1],
+            $this->getMockHasResult()
+        );
         $this->assertFalse($validator->isValid('value3'));
     }
 
@@ -134,8 +148,12 @@ class NoRecordExistsTest extends \PHPUnit_Framework_TestCase
      */
     public function testExcludeWithArrayNoRecord()
     {
-        $validator = new NoRecordExists('users', 'field1', ['field' => 'id', 'value' => 1],
-                                        $this->getMockNoResult());
+        $validator = new NoRecordExists(
+            'users',
+            'field1',
+            ['field' => 'id', 'value' => 1],
+            $this->getMockNoResult()
+        );
         $this->assertTrue($validator->isValid('nosuchvalue'));
     }
 
@@ -172,8 +190,10 @@ class NoRecordExistsTest extends \PHPUnit_Framework_TestCase
     public function testThrowsExceptionWithNoAdapter()
     {
         $validator = new NoRecordExists('users', 'field1', 'id != 1');
-        $this->setExpectedException('Zend\Validator\Exception\RuntimeException',
-                                    'No database adapter present');
+        $this->setExpectedException(
+            'Zend\Validator\Exception\RuntimeException',
+            'No database adapter present'
+        );
         $validator->isValid('nosuchvalue');
     }
 
@@ -184,8 +204,10 @@ class NoRecordExistsTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithSchema()
     {
-        $validator = new NoRecordExists(['table' => 'users', 'schema' => 'my'],
-                                        'field1', null, $this->getMockHasResult());
+        $validator = new NoRecordExists([
+            'table' => 'users',
+            'schema' => 'my'
+        ], 'field1', null, $this->getMockHasResult());
         $this->assertFalse($validator->isValid('value1'));
     }
 
@@ -196,15 +218,20 @@ class NoRecordExistsTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithSchemaNoResult()
     {
-        $validator = new NoRecordExists(['table' => 'users', 'schema' => 'my'],
-                                        'field1', null,  $this->getMockNoResult());
+        $validator = new NoRecordExists([
+            'table' => 'users',
+            'schema' => 'my'
+        ], 'field1', null, $this->getMockNoResult());
         $this->assertTrue($validator->isValid('value1'));
     }
 
     public function testEqualsMessageTemplates()
     {
         $validator  = new NoRecordExists('users', 'field1');
-        $this->assertAttributeEquals($validator->getOption('messageTemplates'),
-                                     'messageTemplates', $validator);
+        $this->assertAttributeEquals(
+            $validator->getOption('messageTemplates'),
+            'messageTemplates',
+            $validator
+        );
     }
 }

--- a/test/Db/RecordExistsTest.php
+++ b/test/Db/RecordExistsTest.php
@@ -21,6 +21,16 @@ use ZendTest\Validator\Db\TestAsset\TrustingSql92Platform;
  */
 class RecordExistsTest extends \PHPUnit_Framework_TestCase
 {
+    public function setUp()
+    {
+        if (! class_exists(Adapter::class)) {
+            $this->markTestSkipped(
+                'Skipping zend-db-related tests until that component is updated '
+                . 'to zend-servicemanager/zend-eventmanager v3'
+            );
+        }
+    }
+
     /**
      * Return a Mock object for a Db result with rows
      *
@@ -102,9 +112,11 @@ class RecordExistsTest extends \PHPUnit_Framework_TestCase
      */
     public function testBasicFindsRecord()
     {
-        $validator = new RecordExists(['table'   => 'users',
-                                            'field'   => 'field1',
-                                            'adapter' => $this->getMockHasResult()]);
+        $validator = new RecordExists([
+            'table'   => 'users',
+            'field'   => 'field1',
+            'adapter' => $this->getMockHasResult()
+        ]);
         $this->assertTrue($validator->isValid('value1'));
     }
 
@@ -197,8 +209,10 @@ class RecordExistsTest extends \PHPUnit_Framework_TestCase
     public function testThrowsExceptionWithNoAdapter()
     {
         $validator = new RecordExists('users', 'field1', 'id != 1');
-        $this->setExpectedException('Zend\Validator\Exception\RuntimeException',
-                                    'No database adapter present');
+        $this->setExpectedException(
+            'Zend\Validator\Exception\RuntimeException',
+            'No database adapter present'
+        );
         $validator->isValid('nosuchvalue');
     }
 
@@ -209,8 +223,10 @@ class RecordExistsTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithSchema()
     {
-        $validator = new RecordExists(['table' => 'users', 'schema' => 'my'],
-                                      'field1', null, $this->getMockHasResult());
+        $validator = new RecordExists([
+            'table' => 'users',
+            'schema' => 'my'
+        ], 'field1', null, $this->getMockHasResult());
         $this->assertTrue($validator->isValid('value1'));
     }
 
@@ -221,8 +237,10 @@ class RecordExistsTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithSchemaNoResult()
     {
-        $validator = new RecordExists(['table' => 'users', 'schema' => 'my'],
-                                      'field1', null, $this->getMockNoResult());
+        $validator = new RecordExists([
+            'table' => 'users',
+            'schema' => 'my'
+        ], 'field1', null, $this->getMockNoResult());
         $this->assertFalse($validator->isValid('value1'));
     }
 
@@ -232,8 +250,10 @@ class RecordExistsTest extends \PHPUnit_Framework_TestCase
      */
     public function testSelectAcknowledgesTableAndSchema()
     {
-        $validator = new RecordExists(['table' => 'users', 'schema' => 'my'],
-                                      'field1', null, $this->getMockHasResult());
+        $validator = new RecordExists([
+            'table' => 'users',
+            'schema' => 'my'
+        ], 'field1', null, $this->getMockHasResult());
         $table = $validator->getSelect()->getRawState('table');
         $this->assertInstanceOf('Zend\Db\Sql\TableIdentifier', $table);
         $this->assertEquals(['users', 'my'], $table->getTableAndSchema());
@@ -242,8 +262,11 @@ class RecordExistsTest extends \PHPUnit_Framework_TestCase
     public function testEqualsMessageTemplates()
     {
         $validator  = new RecordExists('users', 'field1');
-        $this->assertAttributeEquals($validator->getOption('messageTemplates'),
-                                     'messageTemplates', $validator);
+        $this->assertAttributeEquals(
+            $validator->getOption('messageTemplates'),
+            'messageTemplates',
+            $validator
+        );
     }
 
     /**

--- a/test/ValidatorPluginManagerCompatibilityTest.php
+++ b/test/ValidatorPluginManagerCompatibilityTest.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zend-validator for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Validator;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use ReflectionProperty;
+use Zend\Validator\Exception\RuntimeException;
+use Zend\Validator\ValidatorInterface;
+use Zend\Validator\ValidatorPluginManager;
+use Zend\ServiceManager\ServiceManager;
+use Zend\ServiceManager\Test\CommonPluginManagerTrait;
+
+class ValidatorPluginManagerCompatibilityTest extends TestCase
+{
+    use CommonPluginManagerTrait;
+
+    protected function getPluginManager()
+    {
+        return new ValidatorPluginManager(new ServiceManager());
+    }
+
+    protected function getV2InvalidPluginException()
+    {
+        return RuntimeException::class;
+    }
+
+    protected function getInstanceOf()
+    {
+        return ValidatorInterface::class;
+    }
+
+    public function aliasProvider()
+    {
+        $pluginManager = $this->getPluginManager();
+        $r = new ReflectionProperty($pluginManager, 'aliases');
+        $r->setAccessible(true);
+        $aliases = $r->getValue($pluginManager);
+
+        foreach ($aliases as $alias => $target) {
+            // Skipping due to required options
+            if (strpos($target, '\\Barcode')) {
+                continue;
+            }
+
+            // Skipping due to required options
+            if (strpos($target, '\\Between')) {
+                continue;
+            }
+
+            // Skipping due to required options
+            if (strpos($target, '\\Db\\')) {
+                continue;
+            }
+
+            // Skipping due to required options
+            if (strpos($target, '\\File\\ExcludeExtension')) {
+                continue;
+            }
+
+            // Skipping due to required options
+            if (strpos($target, '\\File\\Extension')) {
+                continue;
+            }
+
+            // Skipping due to required options
+            if (strpos($target, '\\File\\FilesSize')) {
+                continue;
+            }
+
+            // Skipping due to required options
+            if (strpos($target, '\\Regex')) {
+                continue;
+            }
+
+            yield $alias => [$alias, $target];
+        }
+    }
+}


### PR DESCRIPTION
This patch builds on the commits from #50, and adds the following changes to the `ValidatorPluginManager` to guarantee v2 + v3 compatibility:

- Use the same signature as the v2 abstract plugin manager.
- In the constructor, call `addInitializer()` instead of adding initializers to the configuration array; guarantees compatibility.
- Add `$shareByDefault` property as alias for `$sharedByDefault`.
- Selectively skip tests for components not yet forwards-compatible (zend-db, zend-session).
- Added a plugin manager compatibility test based on the trait from zend-servicemanager.

and various and other sundry updates. Currently tested against both v2 and v3 of the servicemanager, on all platforms.

~~Currently, several tests fail due to pending zend-i18n updates. Additionally, since several dependencies also require zend-servicemanager and have not yet been updated to work with both v2 and v3, v2 tests cannot run.~~