### PR TITLE
Fixes $options = null check when use Zend\Valdator\Barcode

### DIFF
--- a/src/Barcode.php
+++ b/src/Barcode.php
@@ -48,6 +48,10 @@ class Barcode extends AbstractValidator
      */
     public function __construct($options = null)
     {
+        if ($options === null) {
+            $options = [];
+        }
+
         if (!is_array($options) && !($options instanceof Traversable)) {
             $options = ['adapter' => $options];
         }

--- a/test/BarcodeTest.php
+++ b/test/BarcodeTest.php
@@ -18,6 +18,22 @@ use Zend\Validator\Barcode;
  */
 class BarcodeTest extends \PHPUnit_Framework_TestCase
 {
+    public function provideBarcodeConstructor()
+    {
+        return [
+            [null, Barcode\Ean13::class],
+            [[], Barcode\Ean13::class],
+        ];
+    }
+    /**
+     * @dataProvider provideBarcodeConstructor
+     */
+    public function testBarcodeConstructor($options, $expectedInstance)
+    {
+        $barcode = new Barcode($options);
+        $this->assertInstanceOf($expectedInstance, $barcode->getAdapter());
+    }
+
     public function testNoneExisting()
     {
         $this->setExpectedException('Zend\Validator\Exception\InvalidArgumentException', 'not found');


### PR DESCRIPTION
the constructor has optional `$options = null` but no check for it, this PR fixes it.