### PR TITLE
Prevent IP validation from being triggered for hostnames that only contain IP chars

### DIFF
--- a/src/Hostname.php
+++ b/src/Hostname.php
@@ -1500,7 +1500,8 @@ class Hostname extends AbstractValidator
 
         $this->setValue($value);
         // Check input against IP address schema
-        if (preg_match('/^[0-9a-f:.]*$/i', $value)
+        if (((preg_match('/^[0-9.]*$/', $value) && strpos($value, '.') !== false)
+                || (preg_match('/^[0-9a-f:.]*$/i', $value) && strpos($value, ':') !== false))
             && $this->getIpValidator()->setTranslator($this->getTranslator())->isValid($value)
         ) {
             if (!($this->getAllow() & self::ALLOW_IP)) {

--- a/test/HostnameTest.php
+++ b/test/HostnameTest.php
@@ -527,4 +527,10 @@ class HostnameTest extends \PHPUnit_Framework_TestCase
         $validator = $this->validator;
         $this->assertAttributeEquals($validator->getOption('messageVariables'), 'messageVariables', $validator);
     }
+
+    public function testHostnameWithOnlyIpChars()
+    {
+        $validator = new Hostname();
+        $this->assertTrue($validator->isValid('cafecafe.de'));
+    }
 }


### PR DESCRIPTION
IP validation was triggered for hostnames that contain only IP-characters (0-9a-f:.).