### PR TITLE
escaped "." in regex for ipv4 Validation

### DIFF
--- a/src/Ip.php
+++ b/src/Ip.php
@@ -97,15 +97,15 @@ class Ip extends AbstractValidator
      */
     protected function validateIPv4($value)
     {
-        if (preg_match('/^([01]{8}.){3}[01]{8}\z/i', $value)) {
+	if (preg_match('/^([01]{8}\.){3}[01]{8}\z/i', $value)) {
             // binary format  00000000.00000000.00000000.00000000
             $value = bindec(substr($value, 0, 8)) . '.' . bindec(substr($value, 9, 8)) . '.'
                    . bindec(substr($value, 18, 8)) . '.' . bindec(substr($value, 27, 8));
-        } elseif (preg_match('/^([0-9]{3}.){3}[0-9]{3}\z/i', $value)) {
+        } elseif (preg_match('/^([0-9]{3}\.){3}[0-9]{3}\z/i', $value)) {
             // octet format 777.777.777.777
             $value = (int) substr($value, 0, 3) . '.' . (int) substr($value, 4, 3) . '.'
                    . (int) substr($value, 8, 3) . '.' . (int) substr($value, 12, 3);
-        } elseif (preg_match('/^([0-9a-f]{2}.){3}[0-9a-f]{2}\z/i', $value)) {
+        } elseif (preg_match('/^([0-9a-f]{2}\.){3}[0-9a-f]{2}\z/i', $value)) {
             // hex format ff.ff.ff.ff
             $value = hexdec(substr($value, 0, 2)) . '.' . hexdec(substr($value, 3, 2)) . '.'
                    . hexdec(substr($value, 6, 2)) . '.' . hexdec(substr($value, 9, 2));


### PR DESCRIPTION
"." was not literal dot but any-char , IP "11111111111" was valid