### PR TITLE
Re-enable zend-db and zend-session tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,6 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
   - if [[ $SERVICE_MANAGER_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:$SERVICE_MANAGER_VERSION" ; fi
   - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0.3" ; fi
-  - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer remove --dev --no-update zendframework/zend-db zendframework/zend-session ; fi
 
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs

--- a/composer.json
+++ b/composer.json
@@ -20,13 +20,13 @@
     "require-dev": {
         "zendframework/zend-cache": "^2.6.1",
         "zendframework/zend-config": "^2.6",
-        "zendframework/zend-db": "^2.5",
+        "zendframework/zend-db": "^2.7",
         "zendframework/zend-filter": "^2.6",
         "zendframework/zend-http": "^2.5.4",
         "zendframework/zend-i18n": "^2.6",
         "zendframework/zend-math": "^2.6",
         "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
-        "zendframework/zend-session": "^2.5",
+        "zendframework/zend-session": "^2.6.2",
         "zendframework/zend-uri": "^2.5",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "^4.0"

--- a/test/CsrfTest.php
+++ b/test/CsrfTest.php
@@ -28,13 +28,6 @@ class CsrfTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        if (! class_exists(Container::class)) {
-            $this->markTestSkipped(
-                'Skipping zend-session-related tests until the component is updated '
-                . ' to zend-servicemanager/zend-eventmanager v3'
-            );
-        }
-
         // Setup session handling
         $_SESSION = [];
         $sessionConfig = new StandardConfig([

--- a/test/Db/AbstractDbTest.php
+++ b/test/Db/AbstractDbTest.php
@@ -24,13 +24,6 @@ class AbstractDbTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        if (! class_exists('Zend\Db\Adapter\Adapter')) {
-            $this->markTestSkipped(
-                'Skipping zend-db-related tests until that component is updated '
-                . 'to zend-servicemanager/zend-eventmanager v3'
-            );
-        }
-
         $this->validator = new ConcreteDbValidator([
             'table' => 'table',
             'field' => 'field',

--- a/test/Db/NoRecordExistsTest.php
+++ b/test/Db/NoRecordExistsTest.php
@@ -18,16 +18,6 @@ use ArrayObject;
  */
 class NoRecordExistsTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
-    {
-        if (! class_exists('Zend\Db\Adapter\Adapter')) {
-            $this->markTestSkipped(
-                'Skipping zend-db-related tests until that component is updated '
-                . 'to zend-servicemanager/zend-eventmanager v3'
-            );
-        }
-    }
-
     /**
      * Return a Mock object for a Db result with rows
      *

--- a/test/Db/RecordExistsTest.php
+++ b/test/Db/RecordExistsTest.php
@@ -21,16 +21,6 @@ use ZendTest\Validator\Db\TestAsset\TrustingSql92Platform;
  */
 class RecordExistsTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
-    {
-        if (! class_exists(Adapter::class)) {
-            $this->markTestSkipped(
-                'Skipping zend-db-related tests until that component is updated '
-                . 'to zend-servicemanager/zend-eventmanager v3'
-            );
-        }
-    }
-
     /**
      * Return a Mock object for a Db result with rows
      *


### PR DESCRIPTION
Since zend-db and zend-session each have known-stable, forwards-compatible versions available, we can re-enable tests against them on Travis.