### PR TITLE
Update EmailAddress.php

### DIFF
--- a/src/EmailAddress.php
+++ b/src/EmailAddress.php
@@ -340,7 +340,7 @@ class EmailAddress extends AbstractValidator
         // atext: ALPHA / DIGIT / and "!", "#", "$", "%", "&", "'", "*",
         //        "+", "-", "/", "=", "?", "^", "_", "`", "{", "|", "}", "~"
         $atext = 'a-zA-Z0-9\x21\x23\x24\x25\x26\x27\x2a\x2b\x2d\x2f\x3d\x3f\x5e\x5f\x60\x7b\x7c\x7d\x7e';
-        if (preg_match('/^[' . $atext . ']+(\x2e+[' . $atext . ']+)*$/', $this->idnToAscii($this->localPart))) {
+        if (preg_match('/^[' . $atext . ']+(\x2e[' . $atext . ']+)*$/', $this->idnToAscii($this->localPart))) {
             $result = true;
         } else {
             // Try quoted string format (RFC 5321 Chapter 4.1.2)


### PR DESCRIPTION
Currently, the regex is validating email addresses with the dot at the end of the local part and also multiple consecutive dots so email addresses such local.part.@domain.ext is valid and so is local...part@domain.ext. See RFC 5321 for allowed dot-atom formats. Proposed fix contains only removal of a + (plus) sign from the expression "if (preg_match('/^[' . $atext . ']+(\x2e[' . $atext . ']+)*$/', $this->idnToAscii($this->localPart))) {", right after \x2e.