### PR TITLE
Expose as a generic config provider and ZF component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,10 @@
         "branch-alias": {
             "dev-master": "2.6-dev",
             "dev-develop": "2.7-dev"
+        },
+        "zf": {
+            "component": "Zend\\Validator",
+            "config-provider": "Zend\\Validator\\ConfigProvider"
         }
     },
     "autoload-dev": {

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-validator for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Validator;
+
+class ConfigProvider
+{
+    /**
+     * Return configuration for this component.
+     *
+     * @return array
+     */
+    public function __invoke()
+    {
+        return [
+            'dependencies' => $this->getDependencyConfig(),
+        ];
+    }
+
+    /**
+     * Return dependency mappings for this component.
+     *
+     * @return array
+     */
+    public function getDependencyConfig()
+    {
+        return [
+            'factories' => [
+                'ValidatorManager' => ValidatorPluginManagerFactory::class,
+            ],
+        ];
+    }
+}

--- a/src/Module.php
+++ b/src/Module.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-validator for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Validator;
+
+class Module
+{
+    /**
+     * Return default zend-validator configuration for zend-mvc applications.
+     */
+    public function getConfig()
+    {
+        $provider = new ConfigProvider();
+
+        return [
+            'service_manager' => $provider->getDependencyConfig(),
+        ];
+    }
+
+    /**
+     * Register a specification for the ValidatorManager with the ServiceListener.
+     *
+     * @param \Zend\ModuleManager\ModuleEvent
+     * @return void
+     */
+    public function init($event)
+    {
+        $container = $event->getParam('ServiceManager');
+        $serviceListener = $container->get('ServiceListener');
+
+        $serviceListener->addServiceManager(
+            'ValidatorManager',
+            'validators',
+            'Zend\ModuleManager\Feature\ValidatorProviderInterface',
+            'getValidatorConfig'
+        );
+    }
+}

--- a/src/ValidatorPluginManagerFactory.php
+++ b/src/ValidatorPluginManagerFactory.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-validator for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Validator;
+
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class ValidatorPluginManagerFactory implements FactoryInterface
+{
+    /**
+     * zend-servicemanager v2 support for invocation options.
+     *
+     * @param array
+     */
+    protected $creationOptions;
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return ValidatorPluginManager
+     */
+    public function __invoke(ContainerInterface $container, $name, array $options = null)
+    {
+        return new ValidatorPluginManager($container, $options ?: []);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return ValidatorPluginManager
+     */
+    public function createService(ServiceLocatorInterface $container, $name = null, $requestedName = null)
+    {
+        return $this($container, $requestedName ?: ValidatorPluginManager::class, $this->creationOptions);
+    }
+
+    /**
+     * zend-servicemanager v2 support for invocation options.
+     *
+     * @param array $options
+     * @return void
+     */
+    public function setCreationOptions(array $options)
+    {
+        $this->creationOptions = $options;
+    }
+}

--- a/test/ValidatorPluginManagerFactoryTest.php
+++ b/test/ValidatorPluginManagerFactoryTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-validator for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Validator;
+
+use Interop\Container\ContainerInterface;
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Validator\ValidatorInterface;
+use Zend\Validator\ValidatorPluginManager;
+use Zend\Validator\ValidatorPluginManagerFactory;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class ValidatorPluginManagerFactoryTest extends TestCase
+{
+    public function testFactoryReturnsPluginManager()
+    {
+        $container = $this->prophesize(ContainerInterface::class)->reveal();
+        $factory = new ValidatorPluginManagerFactory();
+
+        $validators = $factory($container, ValidatorPluginManagerFactory::class);
+        $this->assertInstanceOf(ValidatorPluginManager::class, $validators);
+
+        if (method_exists($validators, 'configure')) {
+            // zend-servicemanager v3
+            $this->assertAttributeSame($container, 'creationContext', $validators);
+        } else {
+            // zend-servicemanager v2
+            $this->assertSame($container, $validators->getServiceLocator());
+        }
+    }
+
+    /**
+     * @depends testFactoryReturnsPluginManager
+     */
+    public function testFactoryConfiguresPluginManagerUnderContainerInterop()
+    {
+        $container = $this->prophesize(ContainerInterface::class)->reveal();
+        $validator = $this->prophesize(ValidatorInterface::class)->reveal();
+
+        $factory = new ValidatorPluginManagerFactory();
+        $validators = $factory($container, ValidatorPluginManagerFactory::class, [
+            'services' => [
+                'test' => $validator,
+            ],
+        ]);
+        $this->assertSame($validator, $validators->get('test'));
+    }
+
+    /**
+     * @depends testFactoryReturnsPluginManager
+     */
+    public function testFactoryConfiguresPluginManagerUnderServiceManagerV2()
+    {
+        $container = $this->prophesize(ServiceLocatorInterface::class);
+        $container->willImplement(ContainerInterface::class);
+
+        $validator = $this->prophesize(ValidatorInterface::class)->reveal();
+
+        $factory = new ValidatorPluginManagerFactory();
+        $factory->setCreationOptions([
+            'services' => [
+                'test' => $validator,
+            ],
+        ]);
+
+        $validators = $factory->createService($container->reveal());
+        $this->assertSame($validator, $validators->get('test'));
+    }
+}


### PR DESCRIPTION
Adds:

- `ValidatorPluginManagerFactory` for creating and returning a `ValidatorPluginManager` instance.
- `ConfigProvider`, which maps the service `ValidatorManager` to the new `ValidatorPluginManagerFactory`.
- `Module`, which maps the service `ValidatorManager` to the new `ValidatorPluginManagerFactory`, and adds zend-modulemanager `ServiceListener` specifications for providing validator configuration.