### PR TITLE
Fix - missing `messageTemplates` in `ExcludeMimeType` validator

### DIFF
--- a/src/File/ExcludeMimeType.php
+++ b/src/File/ExcludeMimeType.php
@@ -22,6 +22,15 @@ class ExcludeMimeType extends MimeType
     const NOT_READABLE = 'fileExcludeMimeTypeNotReadable';
 
     /**
+     * @var array Error message templates
+     */
+    protected $messageTemplates = [
+        self::FALSE_TYPE   => "File has an incorrect mimetype of '%type%'",
+        self::NOT_DETECTED => "The mimetype could not be detected from the file",
+        self::NOT_READABLE => "File is not readable or does not exist",
+    ];
+
+    /**
      * Returns true if the mimetype of the file does not matche the given ones. Also parts
      * of mimetypes can be checked. If you give for example "image" all image
      * mime types will not be accepted like "image/gif", "image/jpeg" and so on.

--- a/test/File/ExcludeMimeTypeTest.php
+++ b/test/File/ExcludeMimeTypeTest.php
@@ -51,6 +51,10 @@ class ExcludeMimeTypeTest extends \PHPUnit_Framework_TestCase
         $validator = new ExcludeMimeType($options);
         $validator->enableHeaderCheck();
         $this->assertEquals($expected, $validator->isValid($isValidParam));
+        if (!$expected) {
+            $this->assertArrayHasKey($validator::FALSE_TYPE, $validator->getMessages());
+            $this->assertNotEmpty($validator->getMessages()[$validator::FALSE_TYPE]);
+        }
     }
 
     /**
@@ -137,6 +141,12 @@ class ExcludeMimeTypeTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse($validator->isValid(''));
         $this->assertArrayHasKey(ExcludeMimeType::NOT_READABLE, $validator->getMessages());
+        $this->assertNotEmpty($validator->getMessages()[ExcludeMimeType::NOT_READABLE]);
+    }
+
+    public function testEmptyArrayFileShouldReturnFalseAdnDisplayNotFoundMessage()
+    {
+        $validator = new ExcludeMimeType();
 
         $filesArray = [
             'name'      => '',
@@ -148,6 +158,7 @@ class ExcludeMimeTypeTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse($validator->isValid($filesArray));
         $this->assertArrayHasKey(ExcludeMimeType::NOT_READABLE, $validator->getMessages());
+        $this->assertNotEmpty($validator->getMessages()[ExcludeMimeType::NOT_READABLE]);
     }
 
     public function testIsValidRaisesExceptionWithArrayNotInFilesFormat()

--- a/test/File/ExcludeMimeTypeTest.php
+++ b/test/File/ExcludeMimeTypeTest.php
@@ -32,15 +32,17 @@ class ExcludeMimeTypeTest extends \PHPUnit_Framework_TestCase
             'type'     => 'image/jpeg',
         ];
 
+        $falseTypeMessage = [ExcludeMimeType::FALSE_TYPE => "File has an incorrect mimetype of 'image/jpeg'"];
+
         return [
             //    Options, isValid Param, Expected value, messages
-            ['image/gif',                 $fileUpload, true],
-            ['image',                     $fileUpload, false, [ExcludeMimeType::FALSE_TYPE => "File has an incorrect mimetype of 'image/jpeg'"]],
-            ['test/notype',               $fileUpload, true],
-            ['image/gif, image/jpeg',     $fileUpload, false, [ExcludeMimeType::FALSE_TYPE => "File has an incorrect mimetype of 'image/jpeg'"]],
-            [['image/vasa', 'image/gif'], $fileUpload, true],
-            [['image/gif', 'jpeg'],       $fileUpload, false, [ExcludeMimeType::FALSE_TYPE => "File has an incorrect mimetype of 'image/jpeg'"]],
-            [['image/gif', 'gif'],        $fileUpload, true],
+            ['image/gif',                 $fileUpload, true,  []],
+            ['image',                     $fileUpload, false, $falseTypeMessage],
+            ['test/notype',               $fileUpload, true,  []],
+            ['image/gif, image/jpeg',     $fileUpload, false, $falseTypeMessage],
+            [['image/vasa', 'image/gif'], $fileUpload, true,  []],
+            [['image/gif', 'jpeg'],       $fileUpload, false, $falseTypeMessage],
+            [['image/gif', 'gif'],        $fileUpload, true,  []],
         ];
     }
 
@@ -54,7 +56,7 @@ class ExcludeMimeTypeTest extends \PHPUnit_Framework_TestCase
      * @param bool $expected
      * @param array $messages
      */
-    public function testBasic($options, array $isValidParam, $expected, array $messages = [])
+    public function testBasic($options, array $isValidParam, $expected, array $messages)
     {
         $validator = new ExcludeMimeType($options);
         $validator->enableHeaderCheck();

--- a/test/File/ExcludeMimeTypeTest.php
+++ b/test/File/ExcludeMimeTypeTest.php
@@ -25,17 +25,21 @@ class ExcludeMimeTypeTest extends \PHPUnit_Framework_TestCase
     {
         $testFile = __DIR__ . '/_files/picture.jpg';
         $fileUpload = [
-            'tmp_name' => $testFile, 'name' => basename($testFile),
-            'size' => 200, 'error' => 0, 'type' => 'image/jpeg'
+            'tmp_name' => $testFile,
+            'name'     => basename($testFile),
+            'size'     => 200,
+            'error'    => 0,
+            'type'     => 'image/jpeg',
         ];
+
         return [
-            //    Options, isValid Param, Expected value
-            ['image/gif',                      $fileUpload, true],
-            ['image',                          $fileUpload, false],
-            ['test/notype',                    $fileUpload, true],
-            ['image/gif, image/jpeg',          $fileUpload, false],
+            //    Options, isValid Param, Expected value, messages
+            ['image/gif',                 $fileUpload, true],
+            ['image',                     $fileUpload, false, [ExcludeMimeType::FALSE_TYPE => "File has an incorrect mimetype of 'image/jpeg'"]],
+            ['test/notype',               $fileUpload, true],
+            ['image/gif, image/jpeg',     $fileUpload, false, [ExcludeMimeType::FALSE_TYPE => "File has an incorrect mimetype of 'image/jpeg'"]],
             [['image/vasa', 'image/gif'], $fileUpload, true],
-            [['image/gif', 'jpeg'],       $fileUpload, false],
+            [['image/gif', 'jpeg'],       $fileUpload, false, [ExcludeMimeType::FALSE_TYPE => "File has an incorrect mimetype of 'image/jpeg'"]],
             [['image/gif', 'gif'],        $fileUpload, true],
         ];
     }
@@ -44,17 +48,18 @@ class ExcludeMimeTypeTest extends \PHPUnit_Framework_TestCase
      * Ensures that the validator follows expected behavior
      *
      * @dataProvider basicBehaviorDataProvider
-     * @return void
+     *
+     * @param string|array $options
+     * @param array $isValidParam
+     * @param bool $expected
+     * @param array $messages
      */
-    public function testBasic($options, $isValidParam, $expected)
+    public function testBasic($options, array $isValidParam, $expected, array $messages = [])
     {
         $validator = new ExcludeMimeType($options);
         $validator->enableHeaderCheck();
         $this->assertEquals($expected, $validator->isValid($isValidParam));
-        if (!$expected) {
-            $this->assertArrayHasKey($validator::FALSE_TYPE, $validator->getMessages());
-            $this->assertNotEmpty($validator->getMessages()[$validator::FALSE_TYPE]);
-        }
+        $this->assertEquals($messages, $validator->getMessages());
     }
 
     /**


### PR DESCRIPTION
Fix for bug reported in #90 