### PR TITLE
fixed a bug where empty $email was passed to idn_to_utf8

### DIFF
--- a/src/EmailAddress.php
+++ b/src/EmailAddress.php
@@ -547,6 +547,9 @@ class EmailAddress extends AbstractValidator
      */
     protected function idnToUtf8($email)
     {
+        if(strlen($email) == 0)
+            return $email;
+            
         if (extension_loaded('intl')) {
             // The documentation does not clarify what kind of failure
             // can happen in idn_to_utf8. One can assume if the source

--- a/src/EmailAddress.php
+++ b/src/EmailAddress.php
@@ -547,8 +547,9 @@ class EmailAddress extends AbstractValidator
      */
     protected function idnToUtf8($email)
     {
-        if (strlen($email) == 0)
+        if (strlen($email) == 0) {
             return $email;
+        }
             
         if (extension_loaded('intl')) {
             // The documentation does not clarify what kind of failure

--- a/src/EmailAddress.php
+++ b/src/EmailAddress.php
@@ -547,7 +547,7 @@ class EmailAddress extends AbstractValidator
      */
     protected function idnToUtf8($email)
     {
-        if(strlen($email) == 0)
+        if (strlen($email) == 0)
             return $email;
             
         if (extension_loaded('intl')) {


### PR DESCRIPTION
checked if $email is not empty before passing it to idn_to_utf8.
idn_to_utf8 throws a warning when value is empty
