### PR TITLE
Callback validator consumes string class name via ::class resolution

### DIFF
--- a/doc/book/validators/callback.md
+++ b/doc/book/validators/callback.md
@@ -123,6 +123,26 @@ if ($valid->isValid($input)) {
 }
 ```
 
+AS of PHP 5.5 you can use ::class resolution for given callback class.
+
+```php
+class MyClass
+{
+    public function __invoke($value)
+    {
+        // some validation
+        return true;
+    }
+}
+
+$valid = new Zend\Validator\Callback(MyClass::class);
+if ($valid->isValid($input)) {
+    // input appears to be valid
+} else {
+    // input is invalid
+}
+```
+
 ## Adding options
 
 `Zend\Validator\Callback` also allows the usage of options which are provided as

--- a/src/Callback.php
+++ b/src/Callback.php
@@ -48,7 +48,7 @@ class Callback extends AbstractValidator
      */
     public function __construct($options = null)
     {
-        if (is_callable($options)) {
+        if (is_callable($options) || is_string($options)) {
             $options = ['callback' => $options];
         }
 
@@ -74,6 +74,10 @@ class Callback extends AbstractValidator
      */
     public function setCallback($callback)
     {
+        if (is_string($callback) && class_exists($callback)) {
+            $callback = new $callback();
+        }
+
         if (!is_callable($callback)) {
             throw new Exception\InvalidArgumentException('Invalid callback given');
         }

--- a/test/CallbackTest.php
+++ b/test/CallbackTest.php
@@ -36,6 +36,12 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($valid->isValid('test'));
     }
 
+    public function testStringClassCallback()
+    {
+        $valid = new Callback(self::class);
+        $this->assertTrue($valid->isValid('test'));
+    }
+
     public function testSettingDefaultOptionsAfterwards()
     {
         $valid = new Callback([$this, 'objectCallback']);
@@ -110,6 +116,11 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
     }
 
     public static function staticCallback($value)
+    {
+        return true;
+    }
+
+    public function __invoke($value)
     {
         return true;
     }


### PR DESCRIPTION
Added ability to inject string class name into callback validator constructor.
