### PR TITLE
ValidatorPluginManagerCompatibilityTest should skip additional validators having required options

### DIFF
--- a/test/ValidatorPluginManagerCompatibilityTest.php
+++ b/test/ValidatorPluginManagerCompatibilityTest.php
@@ -75,6 +75,21 @@ class ValidatorPluginManagerCompatibilityTest extends TestCase
             }
 
             // Skipping due to required options
+            if (strpos($target, '\\GreaterThan')) {
+                continue;
+            }
+
+            // Skipping due to required options
+            if (strpos($target, '\\IsInstanceOf')) {
+                continue;
+            }
+
+            // Skipping due to required options
+            if (strpos($target, '\\LessThan')) {
+                continue;
+            }
+
+            // Skipping due to required options
             if (strpos($target, '\\Regex')) {
                 continue;
             }


### PR DESCRIPTION
Fix for #122 
