### PR TITLE
Adds more info to suggestions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,13 +32,13 @@
         "phpunit/PHPUnit": "^4.0"
     },
     "suggest": {
-        "zendframework/zend-db": "Zend\\Db component",
+        "zendframework/zend-db": "Zend\\Db component, required by the (No)RecordExists validator",
         "zendframework/zend-filter": "Zend\\Filter component, required by the Digits validator",
-        "zendframework/zend-i18n": "Zend\\I18n component to allow translation of validation error messages as well as to use the various Date validators",
-        "zendframework/zend-math": "Zend\\Math component",
+        "zendframework/zend-i18n": "Zend\\I18n component to allow translation of validation error messages",
+        "zendframework/zend-math": "Zend\\Math component, required by the Csrf validator",
         "zendframework/zend-i18n-resources": "Translations of validator messages",
         "zendframework/zend-servicemanager": "Zend\\ServiceManager component to allow using the ValidatorPluginManager and validator chains",
-        "zendframework/zend-session": "Zend\\Session component",
+        "zendframework/zend-session": "Zend\\Session component, required by the Csrf validator",
         "zendframework/zend-uri": "Zend\\Uri component, required by the Uri and Sitemap\\Loc validators"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
This commit adds more infos why separate packages are suggested. This is especially of interest as different Validators are only usable with additional packages like the Csrf- and the (No)RowExists-validator

This addresses #147