### PR TITLE
Ensure `validators` config is honored in non-zend-mvc contexts

### DIFF
--- a/src/ValidatorPluginManagerFactory.php
+++ b/src/ValidatorPluginManagerFactory.php
@@ -8,6 +8,7 @@
 namespace Zend\Validator;
 
 use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\Config;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
@@ -27,7 +28,30 @@ class ValidatorPluginManagerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $name, array $options = null)
     {
-        return new ValidatorPluginManager($container, $options ?: []);
+        $pluginManager = new ValidatorPluginManager($container, $options ?: []);
+
+        // If this is in a zend-mvc application, the ServiceListener will inject
+        // merged configuration during bootstrap.
+        if ($container->has('ServiceListener')) {
+            return $pluginManager;
+        }
+
+        // If we do not have a config service, nothing more to do
+        if (! $container->has('config')) {
+            return $pluginManager;
+        }
+
+        $config = $container->get('config');
+
+        // If we do not have validators configuration, nothing more to do
+        if (! isset($config['validators']) || ! is_array($config['validators'])) {
+            return $pluginManager;
+        }
+
+        // Wire service configuration for validators
+        (new Config($config['validators']))->configureServiceManager($pluginManager);
+
+        return $pluginManager;
     }
 
     /**

--- a/test/ValidatorPluginManagerFactoryTest.php
+++ b/test/ValidatorPluginManagerFactoryTest.php
@@ -97,7 +97,7 @@ class ValidatorPluginManagerFactoryTest extends TestCase
         $container->has('MvcTranslator')->willReturn(false); // necessary due to default initializers
 
         $factory = new ValidatorPluginManagerFactory();
-        $validators = $factory($container->reveal(), 'FormElementManager');
+        $validators = $factory($container->reveal(), 'ValidatorManager');
 
         $this->assertInstanceOf(ValidatorPluginManager::class, $validators);
         $this->assertTrue($validators->has('test'));
@@ -131,7 +131,7 @@ class ValidatorPluginManagerFactoryTest extends TestCase
         $container->has('MvcTranslator')->willReturn(false); // necessary due to default initializers
 
         $factory = new ValidatorPluginManagerFactory();
-        $validators = $factory($container->reveal(), 'FormElementManager');
+        $validators = $factory($container->reveal(), 'ValidatorManager');
 
         $this->assertInstanceOf(ValidatorPluginManager::class, $validators);
         $this->assertFalse($validators->has('test'));
@@ -150,7 +150,7 @@ class ValidatorPluginManagerFactoryTest extends TestCase
         $container->has('MvcTranslator')->willReturn(false); // necessary due to default initializers
 
         $factory = new ValidatorPluginManagerFactory();
-        $validators = $factory($container->reveal(), 'FormElementManager');
+        $validators = $factory($container->reveal(), 'ValidatorManager');
 
         $this->assertInstanceOf(ValidatorPluginManager::class, $validators);
     }
@@ -167,7 +167,7 @@ class ValidatorPluginManagerFactoryTest extends TestCase
         $container->has('MvcTranslator')->willReturn(false); // necessary due to default initializers
 
         $factory = new ValidatorPluginManagerFactory();
-        $validators = $factory($container->reveal(), 'FormElementManager');
+        $validators = $factory($container->reveal(), 'ValidatorManager');
 
         $this->assertInstanceOf(ValidatorPluginManager::class, $validators);
         $this->assertFalse($validators->has('foo'));

--- a/test/ValidatorPluginManagerFactoryTest.php
+++ b/test/ValidatorPluginManagerFactoryTest.php
@@ -140,7 +140,6 @@ class ValidatorPluginManagerFactoryTest extends TestCase
 
     public function testDoesNotConfigureValidatorServicesWhenConfigServiceNotPresent()
     {
-        $validator = $this->prophesize(ValidatorInterface::class)->reveal();
         $container = $this->prophesize(ServiceLocatorInterface::class);
         $container->willImplement(ContainerInterface::class);
 
@@ -157,7 +156,6 @@ class ValidatorPluginManagerFactoryTest extends TestCase
 
     public function testDoesNotConfigureValidatorServicesWhenConfigServiceDoesNotContainValidatorsConfig()
     {
-        $validator = $this->prophesize(ValidatorInterface::class)->reveal();
         $container = $this->prophesize(ServiceLocatorInterface::class);
         $container->willImplement(ContainerInterface::class);
 

--- a/test/ValidatorPluginManagerFactoryTest.php
+++ b/test/ValidatorPluginManagerFactoryTest.php
@@ -9,6 +9,7 @@ namespace ZendTest\Validator;
 
 use Interop\Container\ContainerInterface;
 use PHPUnit\Framework\TestCase;
+use Zend\Validator\Digits;
 use Zend\Validator\ValidatorInterface;
 use Zend\Validator\ValidatorPluginManager;
 use Zend\Validator\ValidatorPluginManagerFactory;
@@ -69,5 +70,106 @@ class ValidatorPluginManagerFactoryTest extends TestCase
 
         $validators = $factory->createService($container->reveal());
         $this->assertSame($validator, $validators->get('test'));
+    }
+
+    public function testConfiguresValidatorServicesWhenFound()
+    {
+        $validator = $this->prophesize(ValidatorInterface::class)->reveal();
+        $config = [
+            'validators' => [
+                'aliases' => [
+                    'test' => Digits::class,
+                ],
+                'factories' => [
+                    'test-too' => function ($container) use ($validator) {
+                        return $validator;
+                    },
+                ],
+            ],
+        ];
+
+        $container = $this->prophesize(ServiceLocatorInterface::class);
+        $container->willImplement(ContainerInterface::class);
+
+        $container->has('ServiceListener')->willReturn(false);
+        $container->has('config')->willReturn(true);
+        $container->get('config')->willReturn($config);
+        $container->has('MvcTranslator')->willReturn(false); // necessary due to default initializers
+
+        $factory = new ValidatorPluginManagerFactory();
+        $validators = $factory($container->reveal(), 'FormElementManager');
+
+        $this->assertInstanceOf(ValidatorPluginManager::class, $validators);
+        $this->assertTrue($validators->has('test'));
+        $this->assertInstanceOf(Digits::class, $validators->get('test'));
+        $this->assertTrue($validators->has('test-too'));
+        $this->assertSame($validator, $validators->get('test-too'));
+    }
+
+    public function testDoesNotConfigureValidatorServicesWhenServiceListenerPresent()
+    {
+        $validator = $this->prophesize(ValidatorInterface::class)->reveal();
+        $config = [
+            'validators' => [
+                'aliases' => [
+                    'test' => Digits::class,
+                ],
+                'factories' => [
+                    'test-too' => function ($container) use ($validator) {
+                        return $validator;
+                    },
+                ],
+            ],
+        ];
+
+        $container = $this->prophesize(ServiceLocatorInterface::class);
+        $container->willImplement(ContainerInterface::class);
+
+        $container->has('ServiceListener')->willReturn(true);
+        $container->has('config')->shouldNotBeCalled();
+        $container->get('config')->shouldNotBeCalled();
+        $container->has('MvcTranslator')->willReturn(false); // necessary due to default initializers
+
+        $factory = new ValidatorPluginManagerFactory();
+        $validators = $factory($container->reveal(), 'FormElementManager');
+
+        $this->assertInstanceOf(ValidatorPluginManager::class, $validators);
+        $this->assertFalse($validators->has('test'));
+        $this->assertFalse($validators->has('test-too'));
+    }
+
+    public function testDoesNotConfigureValidatorServicesWhenConfigServiceNotPresent()
+    {
+        $validator = $this->prophesize(ValidatorInterface::class)->reveal();
+        $container = $this->prophesize(ServiceLocatorInterface::class);
+        $container->willImplement(ContainerInterface::class);
+
+        $container->has('ServiceListener')->willReturn(false);
+        $container->has('config')->willReturn(false);
+        $container->get('config')->shouldNotBeCalled();
+        $container->has('MvcTranslator')->willReturn(false); // necessary due to default initializers
+
+        $factory = new ValidatorPluginManagerFactory();
+        $validators = $factory($container->reveal(), 'FormElementManager');
+
+        $this->assertInstanceOf(ValidatorPluginManager::class, $validators);
+    }
+
+    public function testDoesNotConfigureValidatorServicesWhenConfigServiceDoesNotContainValidatorsConfig()
+    {
+        $validator = $this->prophesize(ValidatorInterface::class)->reveal();
+        $container = $this->prophesize(ServiceLocatorInterface::class);
+        $container->willImplement(ContainerInterface::class);
+
+        $container->has('ServiceListener')->willReturn(false);
+        $container->has('config')->willReturn(true);
+        $container->get('config')->willReturn(['foo' => 'bar']);
+        $container->has('MvcTranslator')->willReturn(false); // necessary due to default initializers
+
+        $factory = new ValidatorPluginManagerFactory();
+        $validators = $factory($container->reveal(), 'FormElementManager');
+
+        $this->assertInstanceOf(ValidatorPluginManager::class, $validators);
+        $this->assertFalse($validators->has('foo'));
     }
 }


### PR DESCRIPTION
Per [a forum post](https://discourse.zendframework.com/t/validatormanager-not-calling-custom-validator-factory/109/5?u=matthew) the `validators` config key is not honored currently unless the application is within a zend-mvc context. This is due to the fact that `Zend\Validator\Module` wires configuration for the `Zend\ModuleManager\Listener\ServiceListener` in order to push merged service configuration into the plugin during bootstrap; no similar logic is available when not in a zend-mvc context, however.

This patch fixes that situation by modifying the `ValidatorPluginManagerFactory` to do the following:

- If a `ServiceListener` service exists, it returns the plugin manager immediately (old behavior).
- Otherwise, it checks for the `config` service, and, if found, a `validators` key with an array value. When found, it feeds that value to a `Zend\ServiceManager\Config` instance and uses that to configure the plugin manager before returning it.