### PR TITLE
Add PHP 7.2 support, drop HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,21 +67,21 @@ matrix:
     - php: 7.1
       env:
         - DEPS=latest
-    - php: hhvm
+    - php: nightly
       env:
         - DEPS=lowest
-    - php: hhvm
+    - php: nightly
       env:
         - DEPS=locked
-    - php: hhvm
+    - php: nightly
       env:
         - DEPS=latest
-    - php: hhvm
+    - php: nightly
       env:
         - DEPS=locked
         - SERVICE_MANAGER_VERSION="^2.7.5"
   allow_failures:
-    - php: hhvm
+    - php: nightly
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ branches:
 
 cache:
   directories:
-    - $HOME/.composer/cache
+    - $HOME/.composer/
     - $HOME/.local
     - zf-mkdoc-theme
 
@@ -91,7 +91,7 @@ install:
   - travis_retry composer install $COMPOSER_ARGS --ignore-platform-reqs
   - if [[ $TRAVIS_PHP_VERSION =~ ^5.6 ]]; then travis_retry composer update $COMPOSER_ARGS --with-dependencies $LEGACY_DEPS ; fi
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
-  - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
+  - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update $COMPOSER_ARGS --prefer-lowest --prefer-stable ; fi
   - if [[ $SERVICE_MANAGER_VERSION != '' ]]; then travis_retry composer require --dev --no-update $COMPOSER_ARGS "zendframework/zend-servicemanager:$SERVICE_MANAGER_VERSION" ; fi
   - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then travis_retry composer require --dev --no-update $COMPOSER_ARGS "zendframework/zend-servicemanager:^3.0.3" ; fi
   - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $COVERAGE_DEPS ; fi
@@ -104,11 +104,11 @@ script:
   - if [[ $EXECUTE_HOSTNAME_CHECK == "true" && $TRAVIS_PULL_REQUEST == "false" ]]; then php bin/update_hostname_validator.php --check-only; fi
   - if [[ $DEPLOY_DOCS == "true" && "$TRAVIS_TEST_RESULT" == "0" ]]; then wget -O theme-installer.sh "https://raw.githubusercontent.com/zendframework/zf-mkdoc-theme/master/theme-installer.sh" ; chmod 755 theme-installer.sh ; ./theme-installer.sh ; fi
 
-after_script:
-  - if [[ $TEST_COVERAGE == 'true' ]]; then composer upload-coverage ; fi
-
 after_success:
   - if [[ $DEPLOY_DOCS == "true" ]]; then echo "Preparing to build and deploy documentation" ; ./zf-mkdoc-theme/deploy.sh ; echo "Completed deploying documentation" ; fi
+
+after_script:
+  - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer upload-coverage ; fi
 
 notifications:
   email: false

--- a/bin/update_hostname_validator.php
+++ b/bin/update_hostname_validator.php
@@ -177,7 +177,9 @@ function getNewValidTlds($string)
 function getPunycodeDecoder()
 {
     if (function_exists('idn_to_utf8')) {
-        return 'idn_to_utf8';
+        return function($domain) {
+            return idn_to_utf8($domain, 0, INTL_IDNA_VARIANT_UTS46);
+        };
     }
 
     $hostnameValidator = new Hostname();

--- a/src/EmailAddress.php
+++ b/src/EmailAddress.php
@@ -530,7 +530,7 @@ class EmailAddress extends AbstractValidator
     protected function idnToAscii($email)
     {
         if (extension_loaded('intl')) {
-            return (idn_to_ascii($email) ?: $email);
+            return (idn_to_ascii($email, 0, INTL_IDNA_VARIANT_UTS46) ?: $email);
         }
         return $email;
     }
@@ -553,7 +553,7 @@ class EmailAddress extends AbstractValidator
             // the source string in those cases.
             // But not when the source string is long enough.
             // Thus we default to source string ourselves.
-            return idn_to_utf8($email) ?: $email;
+            return idn_to_utf8($email, 0, INTL_IDNA_VARIANT_UTS46) ?: $email;
         }
         return $email;
     }

--- a/src/File/Upload.php
+++ b/src/File/Upload.php
@@ -9,6 +9,7 @@
 
 namespace Zend\Validator\File;
 
+use Countable;
 use Zend\Validator\AbstractValidator;
 use Zend\Validator\Exception;
 
@@ -109,7 +110,7 @@ class Upload extends AbstractValidator
      */
     public function setFiles($files = [])
     {
-        if (count($files) === 0) {
+        if ((is_array($files) || $files instanceof Countable) && count($files) === 0) {
             $this->options['files'] = $_FILES;
         } else {
             $this->options['files'] = $files;

--- a/src/File/Upload.php
+++ b/src/File/Upload.php
@@ -110,7 +110,7 @@ class Upload extends AbstractValidator
      */
     public function setFiles($files = [])
     {
-        if ((is_array($files) || $files instanceof Countable) && count($files) === 0) {
+        if (null === $files || ((is_array($files) || $files instanceof Countable) && count($files) === 0)) {
             $this->options['files'] = $_FILES;
         } else {
             $this->options['files'] = $files;


### PR DESCRIPTION
- [x] Adopt recent `.travis.yml` ZF standards ([zend-session/.travis.yml](https://github.com/zendframework/zend-session/blob/develop/.travis.yml) picked)
- [x] Drop HVVM
- [x] Test PHP 7.2
- [x] Add partial PHP 7.2 support
    1. `idn_to_ascii(): INTL_IDNA_VARIANT_2003 is deprecated`
    1. `count(): Parameter must be an array or an object that implements Countable`