### PR TITLE
Fix BC break introduced by 3fc1e66

### DIFF
--- a/src/File/MimeType.php
+++ b/src/File/MimeType.php
@@ -385,7 +385,7 @@ class MimeType extends AbstractValidator
             $this->type = null;
             if (! empty($this->finfo)) {
                 $this->type = finfo_file($this->finfo, $file);
-                finfo_close($this->finfo);
+                unset($this->finfo);
             }
         }
 


### PR DESCRIPTION
Fixes #170 and #176 by using finfo's destructor via unset:

* https://github.com/php/php-src/blob/0437aa2abf1eb494e4555d7d4dfbdbf566a59bdc/ext/fileinfo/fileinfo.c#L185
* https://github.com/php/php-src/blob/0437aa2abf1eb494e4555d7d4dfbdbf566a59bdc/ext/fileinfo/tests/finfo_close_basic.phpt

Thus avoiding the call to an invalid finfo resource while still avoiding the segfault bug on older PHP versions.