### PR TITLE
[WIP] Refactor to stateless validators

### DIFF
--- a/src/AbstractValidator.php
+++ b/src/AbstractValidator.php
@@ -12,29 +12,8 @@ namespace Zend\Validator;
 use Traversable;
 use Zend\Stdlib\ArrayUtils;
 
-abstract class AbstractValidator implements
-    Translator\TranslatorAwareInterface,
-    ValidatorInterface
+abstract class AbstractValidator implements ValidatorInterface
 {
-    /**
-     * The value to be validated
-     *
-     * @var mixed
-     */
-    protected $value;
-
-    /**
-     * Default translation object for all validate objects
-     * @var Translator\TranslatorInterface
-     */
-    protected static $defaultTranslator;
-
-    /**
-     * Default text domain to be used with translator
-     * @var string
-     */
-    protected static $defaultTranslatorTextDomain = 'default';
-
     /**
      * Limits the maximum returned length of an error message
      *
@@ -46,9 +25,6 @@ abstract class AbstractValidator implements
         'messages'             => [], // Array of validation failure messages
         'messageTemplates'     => [], // Array of validation failure message templates
         'messageVariables'     => [], // Array of additional variables available for validation failure messages
-        'translator'           => null,    // Translation object to used -> Translator\TranslatorInterface
-        'translatorTextDomain' => null,    // Translation text domain
-        'translatorEnabled'    => true,    // Is translation enabled?
         'valueObscured'        => false,   // Flag indicating whether or not value should be obfuscated
                                            // in error messages
     ];
@@ -150,27 +126,6 @@ abstract class AbstractValidator implements
     }
 
     /**
-     * Returns array of validation failure messages
-     *
-     * @return array
-     */
-    public function getMessages()
-    {
-        return array_unique($this->abstractOptions['messages'], SORT_REGULAR);
-    }
-
-    /**
-     * Invoke as command
-     *
-     * @param  mixed $value
-     * @return bool
-     */
-    public function __invoke($value)
-    {
-        return $this->isValid($value);
-    }
-
-    /**
      * Returns an array of the names of variables that are used in constructing validation failure messages
      *
      * @return array
@@ -217,149 +172,16 @@ abstract class AbstractValidator implements
     }
 
     /**
-     * Sets validation failure message templates given as an array, where the array keys are the message keys,
-     * and the array values are the message template strings.
-     *
-     * @param  array $messages
-     * @return AbstractValidator
+     * Constructs and returns a validation failure message template associated with the given message key.
      */
-    public function setMessages(array $messages)
-    {
-        foreach ($messages as $key => $message) {
-            $this->setMessage($message, $key);
-        }
-        return $this;
-    }
-
-    /**
-     * Magic function returns the value of the requested property, if and only if it is the value or a
-     * message variable.
-     *
-     * @param  string $property
-     * @return mixed
-     * @throws Exception\InvalidArgumentException
-     */
-    public function __get($property)
-    {
-        if ($property == 'value') {
-            return $this->value;
-        }
-
-        if (array_key_exists($property, $this->abstractOptions['messageVariables'])) {
-            $result = $this->abstractOptions['messageVariables'][$property];
-            if (is_array($result)) {
-                return $this->{key($result)}[current($result)];
-            }
-            return $this->{$result};
-        }
-
-        if (isset($this->messageVariables) && array_key_exists($property, $this->messageVariables)) {
-            $result = $this->{$this->messageVariables[$property]};
-            if (is_array($result)) {
-                return $this->{key($result)}[current($result)];
-            }
-            return $this->{$result};
-        }
-
-        throw new Exception\InvalidArgumentException("No property exists by the name '$property'");
-    }
-
-    /**
-     * Constructs and returns a validation failure message with the given message key and value.
-     *
-     * Returns null if and only if $messageKey does not correspond to an existing template.
-     *
-     * If a translator is available and a translation exists for $messageKey,
-     * the translation will be used.
-     *
-     * @param  string              $messageKey
-     * @param  string|array|object $value
-     * @return string
-     */
-    protected function createMessage($messageKey, $value)
-    {
-        if (! isset($this->abstractOptions['messageTemplates'][$messageKey])) {
-            return;
-        }
-
-        $message = $this->abstractOptions['messageTemplates'][$messageKey];
-
-        $message = $this->translateMessage($messageKey, $message);
-
-        if (is_object($value) &&
-            ! in_array('__toString', get_class_methods($value))
-        ) {
-            $value = get_class($value) . ' object';
-        } elseif (is_array($value)) {
-            $value = var_export($value, 1);
-        } else {
-            $value = (string) $value;
-        }
-
-        if ($this->isValueObscured()) {
-            $value = str_repeat('*', strlen($value));
-        }
-
-        $message = str_replace('%value%', (string) $value, $message);
-        foreach ($this->abstractOptions['messageVariables'] as $ident => $property) {
-            if (is_array($property)) {
-                $value = $this->{key($property)}[current($property)];
-                if (is_array($value)) {
-                    $value = '[' . implode(', ', $value) . ']';
-                }
-            } else {
-                $value = $this->$property;
-            }
-            $message = str_replace("%$ident%", (string) $value, $message);
-        }
-
-        $length = self::getMessageLength();
-        if (($length > -1) && (strlen($message) > $length)) {
-            $message = substr($message, 0, ($length - 3)) . '...';
-        }
-
-        return $message;
-    }
-
-    /**
-     * @param  string $messageKey
-     * @param  string $value      OPTIONAL
-     * @return void
-     */
-    protected function error($messageKey, $value = null)
+    protected function createMessage(string $messageKey) : string
     {
         if ($messageKey === null) {
             $keys = array_keys($this->abstractOptions['messageTemplates']);
             $messageKey = current($keys);
         }
 
-        if ($value === null) {
-            $value = $this->value;
-        }
-
-        $this->abstractOptions['messages'][$messageKey] = $this->createMessage($messageKey, $value);
-    }
-
-    /**
-     * Returns the validation value
-     *
-     * @return mixed Value to be validated
-     */
-    protected function getValue()
-    {
-        return $this->value;
-    }
-
-    /**
-     * Sets the value to be validated and clears the messages and errors arrays
-     *
-     * @param  mixed $value
-     * @return void
-     */
-    protected function setValue($value)
-    {
-        $this->value               = $value;
-        $this->abstractOptions['messages'] = [];
+        return $this->abstractOptions['messageTemplates'][$messageKey] ?? '';
     }
 
     /**
@@ -386,156 +208,6 @@ abstract class AbstractValidator implements
     }
 
     /**
-     * Set translation object
-     *
-     * @param  Translator\TranslatorInterface|null $translator
-     * @param  string          $textDomain (optional)
-     * @return AbstractValidator
-     * @throws Exception\InvalidArgumentException
-     */
-    public function setTranslator(Translator\TranslatorInterface $translator = null, $textDomain = null)
-    {
-        $this->abstractOptions['translator'] = $translator;
-        if (null !== $textDomain) {
-            $this->setTranslatorTextDomain($textDomain);
-        }
-        return $this;
-    }
-
-    /**
-     * Return translation object
-     *
-     * @return Translator\TranslatorInterface|null
-     */
-    public function getTranslator()
-    {
-        if (! $this->isTranslatorEnabled()) {
-            return;
-        }
-
-        if (null === $this->abstractOptions['translator']) {
-            $this->abstractOptions['translator'] = self::getDefaultTranslator();
-        }
-
-        return $this->abstractOptions['translator'];
-    }
-
-    /**
-     * Does this validator have its own specific translator?
-     *
-     * @return bool
-     */
-    public function hasTranslator()
-    {
-        return (bool) $this->abstractOptions['translator'];
-    }
-
-    /**
-     * Set translation text domain
-     *
-     * @param  string $textDomain
-     * @return AbstractValidator
-     */
-    public function setTranslatorTextDomain($textDomain = 'default')
-    {
-        $this->abstractOptions['translatorTextDomain'] = $textDomain;
-        return $this;
-    }
-
-    /**
-     * Return the translation text domain
-     *
-     * @return string
-     */
-    public function getTranslatorTextDomain()
-    {
-        if (null === $this->abstractOptions['translatorTextDomain']) {
-            $this->abstractOptions['translatorTextDomain'] =
-                self::getDefaultTranslatorTextDomain();
-        }
-        return $this->abstractOptions['translatorTextDomain'];
-    }
-
-    /**
-     * Set default translation object for all validate objects
-     *
-     * @param  Translator\TranslatorInterface|null $translator
-     * @param  string          $textDomain (optional)
-     * @return void
-     * @throws Exception\InvalidArgumentException
-     */
-    public static function setDefaultTranslator(Translator\TranslatorInterface $translator = null, $textDomain = null)
-    {
-        static::$defaultTranslator = $translator;
-        if (null !== $textDomain) {
-            self::setDefaultTranslatorTextDomain($textDomain);
-        }
-    }
-
-    /**
-     * Get default translation object for all validate objects
-     *
-     * @return Translator\TranslatorInterface|null
-     */
-    public static function getDefaultTranslator()
-    {
-        return static::$defaultTranslator;
-    }
-
-    /**
-     * Is there a default translation object set?
-     *
-     * @return bool
-     */
-    public static function hasDefaultTranslator()
-    {
-        return (bool) static::$defaultTranslator;
-    }
-
-    /**
-     * Set default translation text domain for all validate objects
-     *
-     * @param  string $textDomain
-     * @return void
-     */
-    public static function setDefaultTranslatorTextDomain($textDomain = 'default')
-    {
-        static::$defaultTranslatorTextDomain = $textDomain;
-    }
-
-    /**
-     * Get default translation text domain for all validate objects
-     *
-     * @return string
-     */
-    public static function getDefaultTranslatorTextDomain()
-    {
-        return static::$defaultTranslatorTextDomain;
-    }
-
-    /**
-     * Indicate whether or not translation should be enabled
-     *
-     * @param  bool $flag
-     * @return AbstractValidator
-     */
-    public function setTranslatorEnabled($flag = true)
-    {
-        $this->abstractOptions['translatorEnabled'] = (bool) $flag;
-        return $this;
-    }
-
-    /**
-     * Is translation enabled?
-     *
-     * @return bool
-     */
-    public function isTranslatorEnabled()
-    {
-        return $this->abstractOptions['translatorEnabled'];
-    }
-
-    /**
      * Returns the maximum allowed message length
      *
      * @return int
@@ -553,22 +225,5 @@ abstract class AbstractValidator implements
     public static function setMessageLength($length = -1)
     {
         static::$messageLength = $length;
-    }
-
-    /**
-     * Translate a validation message
-     *
-     * @param  string $messageKey
-     * @param  string $message
-     * @return string
-     */
-    protected function translateMessage($messageKey, $message)
-    {
-        $translator = $this->getTranslator();
-        if (! $translator) {
-            return $message;
-        }
-
-        return $translator->translate($message, $this->getTranslatorTextDomain());
     }
 }

--- a/src/AbstractValidator.php
+++ b/src/AbstractValidator.php
@@ -15,7 +15,6 @@ use Zend\Stdlib\ArrayUtils;
 abstract class AbstractValidator implements Validator
 {
     protected $abstractOptions = [
-        'messages'             => [], // Array of validation failure messages
         'messageTemplates'     => [], // Array of validation failure message templates
         'messageVariables'     => [], // Array of additional variables available for validation failure messages
     ];

--- a/src/AbstractValidator.php
+++ b/src/AbstractValidator.php
@@ -60,6 +60,35 @@ abstract class AbstractValidator implements Validator
     }
 
     /**
+     * Create and return a result indicating validation failure.
+     *
+     * Use this within validators to create the validation result when a failure
+     * condition occurs. Pass it the value, and an array of message keys.
+     *
+     * If the "value obscured" flag is set, this method will decorate the result
+     * using ObscuredValueValidatorResult before returning it.
+     */
+    protected function createInvalidResult($value, array $messageKeys) : Result
+    {
+        $messageTemplates = array_map(function ($key) {
+            return $this->getMessageTemplate($key);
+        }, $messageKeys);
+
+        $result = ValidatorResult::createInvalidResult(
+            $value,
+            $messageTemplates,
+            $this->getMessageVariables()
+        );
+
+        if ($this->isValueObscured()) {
+            $result = new ObscuredValueValidatorResult($result);
+        }
+
+        return $result;
+    }
+
+
+    /**
      * Returns an option
      *
      * @param string $option Option to be returned
@@ -165,7 +194,6 @@ abstract class AbstractValidator implements Validator
 
         return $this->abstractOptions['messageTemplates'][$messageKey] ?? '';
     }
-
     /**
      * Set flag indicating whether or not value should be obfuscated in messages
      *

--- a/src/AbstractValidator.php
+++ b/src/AbstractValidator.php
@@ -44,7 +44,7 @@ abstract class AbstractValidator implements Validator
         return ValidatorResult::createInvalidResult(
             $value,
             $messageTemplates,
-            $this->getMessageVariables()
+            $this->messageVariables
         );
     }
 

--- a/src/AbstractValidator.php
+++ b/src/AbstractValidator.php
@@ -12,7 +12,7 @@ namespace Zend\Validator;
 use Traversable;
 use Zend\Stdlib\ArrayUtils;
 
-abstract class AbstractValidator implements ValidatorInterface
+abstract class AbstractValidator implements Validator
 {
     /**
      * Limits the maximum returned length of an error message
@@ -147,34 +147,16 @@ abstract class AbstractValidator implements ValidatorInterface
 
     /**
      * Sets the validation failure message template for a particular key
-     *
-     * @param  string $messageString
-     * @param  string $messageKey     OPTIONAL
-     * @return AbstractValidator Provides a fluent interface
-     * @throws Exception\InvalidArgumentException
      */
-    public function setMessage($messageString, $messageKey = null)
+    public function setMessageTemplate(string $messageKey, string $messageString) : void
     {
-        if ($messageKey === null) {
-            $keys = array_keys($this->abstractOptions['messageTemplates']);
-            foreach ($keys as $key) {
-                $this->setMessage($messageString, $key);
-            }
-            return $this;
-        }
-
-        if (! isset($this->abstractOptions['messageTemplates'][$messageKey])) {
-            throw new Exception\InvalidArgumentException("No message template exists for key '$messageKey'");
-        }
-
         $this->abstractOptions['messageTemplates'][$messageKey] = $messageString;
-        return $this;
     }
 
     /**
-     * Constructs and returns a validation failure message template associated with the given message key.
+     * Finds and returns the message template associated with the given message key.
      */
-    protected function createMessage(string $messageKey) : string
+    protected function getMessageTemplate(string $messageKey) : string
     {
         if ($messageKey === null) {
             $keys = array_keys($this->abstractOptions['messageTemplates']);
@@ -205,25 +187,5 @@ abstract class AbstractValidator implements ValidatorInterface
     public function isValueObscured()
     {
         return $this->abstractOptions['valueObscured'];
-    }
-
-    /**
-     * Returns the maximum allowed message length
-     *
-     * @return int
-     */
-    public static function getMessageLength()
-    {
-        return static::$messageLength;
-    }
-
-    /**
-     * Sets the maximum allowed message length
-     *
-     * @param int $length
-     */
-    public static function setMessageLength($length = -1)
-    {
-        static::$messageLength = $length;
     }
 }

--- a/src/AbstractValidator.php
+++ b/src/AbstractValidator.php
@@ -14,13 +14,6 @@ use Zend\Stdlib\ArrayUtils;
 
 abstract class AbstractValidator implements Validator
 {
-    /**
-     * Limits the maximum returned length of an error message
-     *
-     * @var int
-     */
-    protected static $messageLength = -1;
-
     protected $abstractOptions = [
         'messages'             => [], // Array of validation failure messages
         'messageTemplates'     => [], // Array of validation failure message templates

--- a/src/AbstractValidator.php
+++ b/src/AbstractValidator.php
@@ -25,8 +25,6 @@ abstract class AbstractValidator implements Validator
         'messages'             => [], // Array of validation failure messages
         'messageTemplates'     => [], // Array of validation failure message templates
         'messageVariables'     => [], // Array of additional variables available for validation failure messages
-        'valueObscured'        => false,   // Flag indicating whether or not value should be obfuscated
-                                           // in error messages
     ];
 
     /**
@@ -64,9 +62,6 @@ abstract class AbstractValidator implements Validator
      *
      * Use this within validators to create the validation result when a failure
      * condition occurs. Pass it the value, and an array of message keys.
-     *
-     * If the "value obscured" flag is set, this method will decorate the result
-     * using ObscuredValueValidatorResult before returning it.
      */
     protected function createInvalidResult($value, array $messageKeys) : Result
     {
@@ -74,19 +69,12 @@ abstract class AbstractValidator implements Validator
             return $this->getMessageTemplate($key);
         }, $messageKeys);
 
-        $result = ValidatorResult::createInvalidResult(
+        return ValidatorResult::createInvalidResult(
             $value,
             $messageTemplates,
             $this->getMessageVariables()
         );
-
-        if ($this->isValueObscured()) {
-            $result = new ObscuredValueValidatorResult($result);
-        }
-
-        return $result;
     }
-
 
     /**
      * Returns an option
@@ -193,27 +181,5 @@ abstract class AbstractValidator implements Validator
         }
 
         return $this->abstractOptions['messageTemplates'][$messageKey] ?? '';
-    }
-    /**
-     * Set flag indicating whether or not value should be obfuscated in messages
-     *
-     * @param  bool $flag
-     * @return AbstractValidator
-     */
-    public function setValueObscured($flag)
-    {
-        $this->abstractOptions['valueObscured'] = (bool) $flag;
-        return $this;
-    }
-
-    /**
-     * Retrieve flag indicating whether or not value should be obfuscated in
-     * messages
-     *
-     * @return bool
-     */
-    public function isValueObscured()
-    {
-        return $this->abstractOptions['valueObscured'];
     }
 }

--- a/src/Barcode.php
+++ b/src/Barcode.php
@@ -134,9 +134,7 @@ class Barcode extends AbstractValidator
     }
 
     /**
-     * Defined by Zend\Validator\ValidatorInterface
-     *
-     * Returns true if and only if $value contains a valid barcode
+     * Determine if the given $value contains a valid barcode
      *
      * @param  string $value
      * @return bool

--- a/src/Between.php
+++ b/src/Between.php
@@ -157,11 +157,11 @@ class Between extends AbstractValidator
      * Returns true if and only if $value is between min and max options, inclusively
      * if inclusive option is true.
      */
-    public function isValid($value, array $context = []) : Result
+    public function validate($value, array $context = []) : Result
     {
         return $this->getInclusive()
             ? $this->validateInclusive($value, $context)
-            : $this->validate($value, $context);
+            : $this->validateExclusive($value, $context);
     }
 
     private function validateInclusive($value, array $context) : Result
@@ -172,7 +172,7 @@ class Between extends AbstractValidator
         return ValidatorResult::createValidResult($value);
     }
 
-    private function validate($value, array $context) : Result
+    private function validateExclusive($value, array $context) : Result
     {
         if ($this->getMin() >= $value || $value >= $this->getMax()) {
             return $this->createInvalidResult($value, [self::NOT_BETWEEN_STRICT]);

--- a/src/Between.php
+++ b/src/Between.php
@@ -156,26 +156,27 @@ class Between extends AbstractValidator
     /**
      * Returns true if and only if $value is between min and max options, inclusively
      * if inclusive option is true.
-     *
-     * @param  mixed $value
-     * @return bool
      */
-    public function isValid($value)
+    public function isValid($value, array $context = []) : Result
     {
-        $this->setValue($value);
+        return $this->getInclusive()
+            ? $this->validateInclusive($value, $context)
+            : $this->validate($value, $context);
+    }
 
-        if ($this->getInclusive()) {
-            if ($this->getMin() > $value || $value > $this->getMax()) {
-                $this->error(self::NOT_BETWEEN);
-                return false;
-            }
-        } else {
-            if ($this->getMin() >= $value || $value >= $this->getMax()) {
-                $this->error(self::NOT_BETWEEN_STRICT);
-                return false;
-            }
+    private function validateInclusive($value, array $context) : Result
+    {
+        if ($this->getMin() > $value || $value > $this->getMax()) {
+            return $this->createInvalidResult($value, [self::NOT_BETWEEN]);
         }
+        return ValidatorResult::createValidResult($value);
+    }
 
-        return true;
+    private function validate($value, array $context) : Result
+    {
+        if ($this->getMin() >= $value || $value >= $this->getMax()) {
+            return $this->createInvalidResult($value, [self::NOT_BETWEEN_STRICT]);
+        }
+        return ValidatorResult::createValidResult($value);
     }
 }

--- a/src/Bitwise.php
+++ b/src/Bitwise.php
@@ -125,7 +125,7 @@ class Bitwise extends AbstractValidator
      *
      * @throws Exception\RuntimeException for unrecognized operators.
      */
-    public function isValid($value, array $context = []) : Result
+    public function validate($value, array $context = []) : Result
     {
         switch ($this->operator) {
             case (self::OP_AND):

--- a/src/Callback.php
+++ b/src/Callback.php
@@ -113,7 +113,7 @@ class Callback extends AbstractValidator
      * @throws Exception\InvalidArgumentException if no callback present
      * @throws Exception\InvalidArgumentException if callback is not callable
      */
-    public function isValid($value, $context = null) : Result
+    public function validate($value, $context = null) : Result
     {
         $options  = $this->getCallbackOptions();
         $callback = $this->getCallback();

--- a/src/EmailAddress.php
+++ b/src/EmailAddress.php
@@ -479,10 +479,7 @@ class EmailAddress extends AbstractValidator
     }
 
     /**
-     * Defined by Zend\Validator\ValidatorInterface
-     *
-     * Returns true if and only if $value is a valid email address
-     * according to RFC2822
+     * Determine if the given $value is a valid email address per RFC 2822.
      *
      * @link   http://www.ietf.org/rfc/rfc2822.txt RFC2822
      * @link   http://www.columbia.edu/kermit/ascii.html US-ASCII characters

--- a/src/Explode.php
+++ b/src/Explode.php
@@ -37,7 +37,7 @@ class Explode extends AbstractValidator implements ValidatorPluginManagerAwareIn
     protected $valueDelimiter = ',';
 
     /**
-     * @var ValidatorInterface
+     * @var Validator
      */
     protected $validator;
 
@@ -95,7 +95,7 @@ class Explode extends AbstractValidator implements ValidatorPluginManagerAwareIn
     /**
      * Sets the Validator for validating each value
      *
-     * @param ValidatorInterface|array $validator
+     * @param Validator|array $validator
      * @throws Exception\RuntimeException
      * @return Explode
      */
@@ -112,7 +112,7 @@ class Explode extends AbstractValidator implements ValidatorPluginManagerAwareIn
             $validator = $this->getValidatorPluginManager()->get($name, $options);
         }
 
-        if (! $validator instanceof ValidatorInterface) {
+        if (! $validator instanceof Validator) {
             throw new Exception\RuntimeException(
                 'Invalid validator given'
             );
@@ -125,7 +125,7 @@ class Explode extends AbstractValidator implements ValidatorPluginManagerAwareIn
     /**
      * Gets the Validator for validating each value
      *
-     * @return ValidatorInterface
+     * @return Validator
      */
     public function getValidator()
     {
@@ -155,9 +155,7 @@ class Explode extends AbstractValidator implements ValidatorPluginManagerAwareIn
     }
 
     /**
-     * Defined by Zend\Validator\ValidatorInterface
-     *
-     * Returns true if all values validate true
+     * Returns true if all values validate true.
      *
      * @param  mixed $value
      * @param  mixed $context Extra "context" to provide the composed validator

--- a/src/File/MimeType.php
+++ b/src/File/MimeType.php
@@ -329,11 +329,11 @@ class MimeType extends AbstractValidator
     }
 
     /**
-     * Defined by Zend\Validator\ValidatorInterface
+     * Determine if the file matches the accepted mimetypes.
      *
-     * Returns true if the mimetype of the file matches the given ones. Also parts
-     * of mimetypes can be checked. If you give for example "image" all image
-     * mime types will be accepted like "image/gif", "image/jpeg" and so on.
+     * Also, parts of mimetypes can be checked. If you give for example "image"
+     * all image mime types will be accepted like "image/gif", "image/jpeg" and
+     * so on.
      *
      * @param  string|array $value Real file to check for mimetype
      * @param  array        $file  File data from \Zend\File\Transfer\Transfer (optional)

--- a/src/ObscuredValueValidatorResult.php
+++ b/src/ObscuredValueValidatorResult.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-validator for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-validator/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Validator;
+
+class ObscuredValueValidatorResult implements Result
+{
+    use ValidatorResultDecorator;
+    use ValidatorResultMessageInterpolator;
+
+    public function __construct(Result $result)
+    {
+        $this->result = $result;
+    }
+
+    /**
+     * Override `getMessages()` to ensure value is obscured.
+     *
+     * Recreates the logic of ValidatorResult::getMessages in order to ensure
+     * that the decorator's getValue() is called when substituting the value
+     * into message templates.
+     */
+    public function getMessages() : array
+    {
+        $messages = [];
+        foreach ($this->result->getMessageTemplates() as $template) {
+            $messages[] = $this->interpolateMessageVariables($template, $this);
+        }
+        return $messages;
+    }
+
+    /**
+     * Returns an obscured version of the value.
+     *
+     * Casts the value to a string, and then replaces all characters with '*'.
+     *
+     * @return string
+     */
+    public function getValue()
+    {
+        $value = $this->castValueToString($this->result->getValue());
+        return str_repeat('*', strlen($value));
+    }
+}

--- a/src/Result.php
+++ b/src/Result.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-validator for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-validator/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Validator;
+
+interface Result
+{
+    public function isValid() : bool;
+
+    public function getMessages() : array;
+
+    public function getMessageTemplates() : array;
+
+    public function getMessageVariables() : array;
+
+    /**
+     * @return mixed
+     */
+    public function getValue();
+}

--- a/src/ResultAggregate.php
+++ b/src/ResultAggregate.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-validator for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-validator/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Validator;
+
+use Countable;
+use IteratorAggregate;
+
+/**
+ * Represent aggregates of several results; e.g., for use with chains.
+ */
+interface ResultAggregate extends Countable, IteratorAggregate, Result
+{
+    public function push(Result $result) : void;
+}

--- a/src/TranslatableValidatorResult.php
+++ b/src/TranslatableValidatorResult.php
@@ -7,9 +7,13 @@
 
 namespace Zend\Validator;
 
-class ValidatorResultTranslator
+class TranslatableValidatorResult implements Result
 {
+    use ValidatorResultDecorator;
     use ValidatorResultMessageInterpolator;
+
+    /** @var Result */
+    private $result;
 
     /** @var string Translation text domain */
     private $textDomain;
@@ -17,31 +21,35 @@ class ValidatorResultTranslator
     /** @var Translator\TranslatorInterface */
     private $translator;
 
-    public function __construct(Translator\TranslatorInterface $translator, string $textDomain = null)
-    {
+    public function __construct(
+        Result $result,
+        Translator\TranslatorInterface $translator,
+        string $textDomain = null
+    ) {
+        $this->result     = $result;
         $this->translator = $translator;
         $this->textDomain = $textDomain;
     }
 
     /**
-     * Create translated messages from a ValidatorResult
+     * Returns translated error message strings from the decorated result instance.
      *
-     * Loops through each message template from the ValidatorResult and returns
+     * Loops through each message template from the composed Result and returns
      * translated messages. Each message will have interpolated the composed
      * message variables from the result.
      *
-     * Additionally, if a `%value%` placeholder is found, the ValidatorResult
-     * value will be interpolated.
+     * Additionally, if a `%value%` placeholder is found, the Result value will
+     * be interpolated.
      */
-    public function translateMessages(ValidatorResult $result) : array
+    public function getMessages() : array
     {
-        $value    = $result->getValue();
+        $value    = $this->result->getValue();
         $messages = [];
 
-        foreach ($result->getMessageTemplates() as $template) {
+        foreach ($this->result->getMessageTemplates() as $template) {
             $messages[] = $this->interpolateMessageVariables(
                 $this->translator->translate($template, $this->textDomain),
-                $result
+                $this->result
             );
         }
 

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -22,5 +22,5 @@ interface Validator
      * @return Result
      * @throws Exception\RuntimeException If validation of $value is impossible
      */
-    public function isValid($value, array $context = []) : Result;
+    public function validate($value, array $context = []) : Result;
 }

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -9,18 +9,18 @@
 
 namespace Zend\Validator;
 
-interface ValidatorInterface
+interface Validator
 {
     /**
      * Validate a value.
      *
-     * Returns a ValidatorResult, containing the results of validation.
+     * Returns a Result, containing the results of validation.
      *
      * @param  mixed $value
      * @param  array $context Optional; additional context for validation, such
      *     as other form values.
-     * @return ValidatorResult
+     * @return Result
      * @throws Exception\RuntimeException If validation of $value is impossible
      */
-    public function isValid($value, array $context = []) : ValidatorResult;
+    public function isValid($value, array $context = []) : Result;
 }

--- a/src/ValidatorChain.php
+++ b/src/ValidatorChain.php
@@ -15,7 +15,7 @@ use Zend\ServiceManager\ServiceManager;
 
 class ValidatorChain implements
     Countable,
-    ValidatorInterface
+    Validator
 {
     /**
      * Default priority at which validators are added
@@ -89,7 +89,7 @@ class ValidatorChain implements
      *
      * @param  string     $name    Name of validator to return
      * @param  null|array $options Options to pass to validator constructor (if not already instantiated)
-     * @return ValidatorInterface
+     * @return Validator
      */
     public function plugin($name, array $options = null)
     {
@@ -103,17 +103,15 @@ class ValidatorChain implements
      * If $breakChainOnFailure is true, then if the validator fails, the next validator in the chain,
      * if one exists, will not be executed.
      *
-     * @param  ValidatorInterface $validator
-     * @param  bool               $breakChainOnFailure
-     * @param  int                $priority            Priority at which to enqueue validator; defaults to
-     *                                                          1 (higher executes earlier)
-     *
+     * @param  Validator $validator
+     * @param  bool $breakChainOnFailure
+     * @param  int $priority Priority at which to enqueue validator; defaults
+     *     to 1 (higher executes earlier)
      * @throws Exception\InvalidArgumentException
-     *
      * @return self
      */
     public function attach(
-        ValidatorInterface $validator,
+        Validator $validator,
         $breakChainOnFailure = false,
         $priority = self::DEFAULT_PRIORITY
     ) {
@@ -132,13 +130,13 @@ class ValidatorChain implements
      * Proxy to attach() to keep BC
      *
      * @deprecated Please use attach()
-     * @param  ValidatorInterface      $validator
-     * @param  bool                 $breakChainOnFailure
-     * @param  int                  $priority
+     * @param Validator $validator
+     * @param bool $breakChainOnFailure
+     * @param int $priority
      * @return ValidatorChain Provides a fluent interface
      */
     public function addValidator(
-        ValidatorInterface $validator,
+        Validator $validator,
         $breakChainOnFailure = false,
         $priority = self::DEFAULT_PRIORITY
     ) {
@@ -151,11 +149,11 @@ class ValidatorChain implements
      * If $breakChainOnFailure is true, then if the validator fails, the next validator in the chain,
      * if one exists, will not be executed.
      *
-     * @param  ValidatorInterface      $validator
-     * @param  bool                 $breakChainOnFailure
+     * @param  Validator $validator
+     * @param  bool $breakChainOnFailure
      * @return ValidatorChain Provides a fluent interface
      */
-    public function prependValidator(ValidatorInterface $validator, $breakChainOnFailure = false)
+    public function prependValidator(Validator $validator, $breakChainOnFailure = false)
     {
         $priority = self::DEFAULT_PRIORITY;
 

--- a/src/ValidatorInterface.php
+++ b/src/ValidatorInterface.php
@@ -12,27 +12,15 @@ namespace Zend\Validator;
 interface ValidatorInterface
 {
     /**
-     * Returns true if and only if $value meets the validation requirements
+     * Validate a value.
      *
-     * If $value fails validation, then this method returns false, and
-     * getMessages() will return an array of messages that explain why the
-     * validation failed.
+     * Returns a ValidatorResult, containing the results of validation.
      *
      * @param  mixed $value
-     * @return bool
+     * @param  array $context Optional; additional context for validation, such
+     *     as other form values.
+     * @return ValidatorResult
      * @throws Exception\RuntimeException If validation of $value is impossible
      */
-    public function isValid($value);
-
-    /**
-     * Returns an array of messages that explain why the most recent isValid()
-     * call returned false. The array keys are validation failure message identifiers,
-     * and the array values are the corresponding human-readable message strings.
-     *
-     * If isValid() was never called or if the most recent isValid() call
-     * returned true, then this method returns an empty array.
-     *
-     * @return array
-     */
-    public function getMessages();
+    public function isValid($value, array $context = []) : ValidatorResult;
 }

--- a/src/ValidatorPluginManager.php
+++ b/src/ValidatorPluginManager.php
@@ -367,7 +367,7 @@ class ValidatorPluginManager extends AbstractPluginManager
      *
      * @var string
      */
-    protected $instanceOf = ValidatorInterface::class;
+    protected $instanceOf = Validator::class;
 
     /**
      * Constructor
@@ -418,7 +418,7 @@ class ValidatorPluginManager extends AbstractPluginManager
             throw new Exception\RuntimeException(sprintf(
                 'Plugin of type %s is invalid; must implement %s',
                 (is_object($plugin) ? get_class($plugin) : gettype($plugin)),
-                ValidatorInterface::class
+                Validator::class
             ), $e->getCode(), $e);
         }
     }

--- a/src/ValidatorResult.php
+++ b/src/ValidatorResult.php
@@ -107,7 +107,7 @@ class ValidatorResult implements Result
 
     public function getMessageTemplates() : array
     {
-        return $this->messages;
+        return $this->messageTemplates;
     }
 
     public function getMessageVariables() : array

--- a/src/ValidatorResult.php
+++ b/src/ValidatorResult.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-validator for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-validator/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Validator;
+
+/**
+ * Value object representing results of validation.
+ */
+class ValidatorResult
+{
+    /**
+     * @var bool
+     */
+    private $isValid;
+
+    /**
+     * @var string[]
+     */
+    private $messages = [];
+
+    /**
+     * @var mixed
+     */
+    private $value;
+
+    /**
+     * @param mixed $value
+     * @param bool $isValid
+     * @param string[] $messages
+     */
+    public function __construct($value, bool $isValid, array $messages = [])
+    {
+        $this->value = $value;
+        $this->isValid = $isValid;
+        $this->messages = $messages;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    public static function createValidResult($value) : self
+    {
+        return new self($value, true);
+    }
+
+    /**
+     * @param mixed $value
+     * @param string[] $messages
+     */
+    public static function createInvalidResult($value, array $messages) : self
+    {
+        return new self($value, false, $messages);
+    }
+
+    public function isValid() : bool
+    {
+        return $this->isValid;
+    }
+
+    public function getMessages() : array
+    {
+        return $this->messages;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+}

--- a/src/ValidatorResult.php
+++ b/src/ValidatorResult.php
@@ -10,7 +10,7 @@ namespace Zend\Validator;
 /**
  * Value object representing results of validation.
  */
-class ValidatorResult
+class ValidatorResult implements Result
 {
     use ValidatorResultMessageInterpolator;
 
@@ -87,14 +87,14 @@ class ValidatorResult
     /**
      * Retrieve validation error messages.
      *
-     * If you are not using i18n features, you may use this method to get an
-     * array of validation error messages. The method loops through each
-     * message template and interpolates any message variables discovered in
-     * the string.
+     * This method loops through each message template and interpolates any
+     * message variables discovered in the string.
      *
-     * If you are using i18n features, you should create a ValidatorResultTranslator
-     * instance, and pass this instance to its `translateMessages()` method in
-     * order to get localized messages.
+     * If you are using i18n features, decorate this instance with a
+     * TranslatableValidatorResult.
+     *
+     * If you wish to osbcure the value, decorate this instance with an
+     * ObscuredValueValidatorResult.
      */
     public function getMessages() : array
     {

--- a/src/ValidatorResultAggregate.php
+++ b/src/ValidatorResultAggregate.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-validator for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-validator/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Validator;
+
+class ValidatorResultAggregate implements ResultAggregate
+{
+    /** @var Result[] */
+    private $results = [];
+
+    /** @var mixed */
+    private $value;
+
+    /**
+     * @param mixed $value
+     */
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+
+    public function push(Result $result) : void
+    {
+        $this->results[] = $result;
+    }
+
+    /**
+     * @return int
+     */
+    public function count()
+    {
+        return count($this->results);
+    }
+
+    /**
+     * @return iterable
+     */
+    public function getIterator()
+    {
+        foreach ($this->results as $result) {
+            yield $result;
+        }
+    }
+
+    public function isValid() : bool
+    {
+        return array_reduce($this->results, function (bool $isValid, Result $result) {
+            return $isValid && $result->isValid();
+        }, true);
+    }
+
+    /**
+     * Returns a shallow list of all messages, with variables interpolated.
+     */
+    public function getMessages() : array
+    {
+        return array_reduce($this->results, function (array $messages, Result $result) {
+            return array_merge($messages, $result->getMessages());
+        }, []);
+    }
+
+    /**
+     * Returns a list with message templates from each validator.
+     *
+     * Instead of a shallow list, this contains an array of arrays, with the
+     * second level being the full list of templates for a single validator.
+     */
+    public function getMessageTemplates() : array
+    {
+        return array_reduce($this->results, function (array $templates, Result $result) {
+            $templates[] = $result->getMessageTemplates();
+            return $templates;
+        }, []);
+    }
+
+    /**
+     * Returns a list with message variables from each validator.
+     *
+     * Instead of a shallow list, this contains an array of arrays, with the
+     * second level being the full map of variables for a single validator.
+     */
+    public function getMessageVariables() : array
+    {
+        return array_reduce($this->results, function (array $variables, Result $result) {
+            $variables[] = $result->getMessageVariables();
+            return $variables;
+        }, []);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+}

--- a/src/ValidatorResultDecorator.php
+++ b/src/ValidatorResultDecorator.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-validator for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-validator/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Validator;
+
+trait ValidatorResultDecorator
+{
+    /** @var Result */
+    private $result;
+
+    /**
+     * Proxies to decorated Result instance.
+     */
+    public function isValid() : bool
+    {
+        return $this->result->isValid();
+    }
+
+    /**
+     * Proxies to decorated Result instance.
+     */
+    public function getMessageTemplates() : array
+    {
+        return $this->result->getMessageTemplates();
+    }
+
+    /**
+     * Proxies to decorated Result instance.
+     */
+    public function getMessageVariables() : array
+    {
+        return $this->result->getMessageVariables();
+    }
+
+    /**
+     * Proxies to decorated Result instance.
+     *
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->result->getValue();
+    }
+}

--- a/src/ValidatorResultMessageInterpolator.php
+++ b/src/ValidatorResultMessageInterpolator.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-validator for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-validator/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Validator;
+
+trait ValidatorResultMessageInterpolator
+{
+    private function interpolateMessageVariables(string $message, ValidatorResult $result) : string
+    {
+        $messageVariables = array_merge($result->getMessageVariables(), ['value' => $result->getValue()]);
+        foreach ($messageVariables as $variable => $substitution) {
+            $message = $this->interpolateMessageVariable($message, $variable, $substitution);
+        }
+        return $message;
+    }
+
+    /**
+     * @param mixed $substitution
+     */
+    private function interpolateMessageVariable(string $message, string $variable, $substitution) : string
+    {
+        if (is_object($substitution)) {
+            $substitution = method_exists($substitution, '__toString')
+                ? (string) $substitution
+                : sprintf('%s object', get_class($substitution));
+        }
+
+        $substitution = is_array($substitution)
+            ? sprintf('[%s]', implode(', ', $substitution))
+            : $substitution;
+
+        return str_replace("%$variable%", (string) $substitution, $message);
+    }
+}

--- a/src/ValidatorResultMessageInterpolator.php
+++ b/src/ValidatorResultMessageInterpolator.php
@@ -9,7 +9,7 @@ namespace Zend\Validator;
 
 trait ValidatorResultMessageInterpolator
 {
-    private function interpolateMessageVariables(string $message, ValidatorResult $result) : string
+    private function interpolateMessageVariables(string $message, Result $result) : string
     {
         $messageVariables = array_merge($result->getMessageVariables(), ['value' => $result->getValue()]);
         foreach ($messageVariables as $variable => $substitution) {

--- a/src/ValidatorResultMessageInterpolator.php
+++ b/src/ValidatorResultMessageInterpolator.php
@@ -23,16 +23,24 @@ trait ValidatorResultMessageInterpolator
      */
     private function interpolateMessageVariable(string $message, string $variable, $substitution) : string
     {
-        if (is_object($substitution)) {
-            $substitution = method_exists($substitution, '__toString')
-                ? (string) $substitution
-                : sprintf('%s object', get_class($substitution));
+        return str_replace("%$variable%", $this->castValueToString($substitution), $message);
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private function castValueToString($value) : string
+    {
+        if (is_object($value)) {
+            $value = method_exists($value, '__toString')
+                ? (string) $value
+                : sprintf('%s object', get_class($value));
         }
 
-        $substitution = is_array($substitution)
-            ? sprintf('[%s]', implode(', ', $substitution))
-            : $substitution;
+        $value = is_array($value)
+            ? sprintf('[%s]', implode(', ', $value))
+            : $value;
 
-        return str_replace("%$variable%", (string) $substitution, $message);
+        return (string) $value;
     }
 }

--- a/src/ValidatorResultTranslator.php
+++ b/src/ValidatorResultTranslator.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-validator for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-validator/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Validator;
+
+class ValidatorResultTranslator
+{
+    use ValidatorResultMessageInterpolator;
+
+    /** @var string Translation text domain */
+    private $textDomain;
+
+    /** @var Translator\TranslatorInterface */
+    private $translator;
+
+    public function __construct(Translator\TranslatorInterface $translator, string $textDomain = null)
+    {
+        $this->translator = $translator;
+        $this->textDomain = $textDomain;
+    }
+
+    /**
+     * Create translated messages from a ValidatorResult
+     *
+     * Loops through each message template from the ValidatorResult and returns
+     * translated messages. Each message will have interpolated the composed
+     * message variables from the result.
+     *
+     * Additionally, if a `%value%` placeholder is found, the ValidatorResult
+     * value will be interpolated.
+     */
+    public function translateMessages(ValidatorResult $result) : array
+    {
+        $value    = $result->getValue();
+        $messages = [];
+
+        foreach ($result->getMessageTemplates() as $template) {
+            $messages[] = $this->interpolateMessageVariables(
+                $this->translator->translate($template, $this->textDomain),
+                $result
+            );
+        }
+
+        return $messages;
+    }
+}

--- a/test/BetweenTest.php
+++ b/test/BetweenTest.php
@@ -44,7 +44,7 @@ class BetweenTest extends TestCase
         foreach ($valuesExpected as $element) {
             $validator = new Between(['min' => $element[0], 'max' => $element[1], 'inclusive' => $element[2]]);
             foreach ($element[4] as $input) {
-                $result = $validator->isValid($input);
+                $result = $validator->validate($input);
                 $this->assertInstanceOf(Result::class, $result);
                 $this->assertSame(
                     $element[3],
@@ -137,11 +137,11 @@ class BetweenTest extends TestCase
         $options = new \ArrayObject(['min' => 1, 'max' => 10, 'inclusive' => false]);
         $validator = new Between($options);
 
-        $result = $validator->isValid(5);
+        $result = $validator->validate(5);
         $this->assertInstanceOf(Result::class, $result);
         $this->assertTrue($result->isValid());
 
-        $result = $validator->isValid(10);
+        $result = $validator->validate(10);
         $this->assertInstanceOf(Result::class, $result);
         $this->assertFalse($result->isValid());
     }

--- a/test/BetweenTest.php
+++ b/test/BetweenTest.php
@@ -12,6 +12,7 @@ namespace ZendTest\Validator;
 use PHPUnit\Framework\TestCase;
 use Zend\Validator\Between;
 use Zend\Validator\Exception\InvalidArgumentException;
+use Zend\Validator\Result;
 
 /**
  * @group      Zend_Validator
@@ -43,24 +44,15 @@ class BetweenTest extends TestCase
         foreach ($valuesExpected as $element) {
             $validator = new Between(['min' => $element[0], 'max' => $element[1], 'inclusive' => $element[2]]);
             foreach ($element[4] as $input) {
-                $this->assertEquals(
+                $result = $validator->isValid($input);
+                $this->assertInstanceOf(Result::class, $result);
+                $this->assertSame(
                     $element[3],
-                    $validator->isValid($input),
-                    'Failed values: ' . $input . ":" . implode("\n", $validator->getMessages())
+                    $result->isValid(),
+                    'Failed values: ' . $input . ":" . implode("\n", $result->getMessages())
                 );
             }
         }
-    }
-
-    /**
-     * Ensures that getMessages() returns expected default value
-     *
-     * @return void
-     */
-    public function testGetMessages()
-    {
-        $validator = new Between(['min' => 1, 'max' => 10]);
-        $this->assertEquals([], $validator->getMessages());
     }
 
     /**
@@ -140,12 +132,17 @@ class BetweenTest extends TestCase
         $this->assertFalse($validator->getInclusive());
     }
 
-    public function testConstructWithTravesableOptions()
+    public function testConstructWithTraversableOptions()
     {
         $options = new \ArrayObject(['min' => 1, 'max' => 10, 'inclusive' => false]);
         $validator = new Between($options);
 
-        $this->assertTrue($validator->isValid(5));
-        $this->assertFalse($validator->isValid(10));
+        $result = $validator->isValid(5);
+        $this->assertInstanceOf(Result::class, $result);
+        $this->assertTrue($result->isValid());
+
+        $result = $validator->isValid(10);
+        $this->assertInstanceOf(Result::class, $result);
+        $this->assertFalse($result->isValid());
     }
 }


### PR DESCRIPTION
This work-in-progress is exploring how we might approach _stateless validators_.

Essentially, instead of an `isValid()` method returning a boolean, and a subsequent call on the validator to retrieve validation error messages, we would instead:

- Define a `Result` interface modeling the results of validation; it would compose the value validated, validation status, and, if present, any validation error messages.
- Define validators would define a single `validate()` method, accepting both a value and optional context, and return a `Result` instance.
- Define a `ResultAggregate` interface for aggregating several results, as is necessary in a `ValidatorChain`; `Result` instances would be pushed upon an aggregate.

Translation, value obscuration, and message truncation then become _presentation_ issues, and can be achieved by decorating `Result` instances.

Additionally, we'd remove the concept of `$options` for creating individual validator instances; they would instead have concrete constructor arguments. This simplifies a ton of logic internally, but means that each validator would require its own factory class. On the flip side, it also means developers can write factories for specific options combinations, and have shared instances without worrying about state.

Migration concerns
------------------

We could create a new minor release that adds the new `Validator`, `Result`, and `ResultAggregate` interfaces, and various `Result` implementations. `Validator` would define `validate` instead of `isValid()`, allowing devs to implement both in order to forward-proof their validators. We could also provide a wrapper for `Validator` implementations to make them work as `ValidatorInterface` instances; in such a case, it would pull info from the result in order to populate its members. 

The bigger issue is _existing_ validators, and extensions to them. Developers extending _existing_ validators may want to copy/paste implementations and begin migration of those to make them forwards-compatible with version 3. Since we would have version 3 released simultaneously to a v2 with the new interface additions, they could even copy those from v3 to aid their migration.

Integration concerns
--------------------

I have not yet investigated impact on zend-inputfilter; however, that version will require a similar refactor towards stateless inputs/input filters as well.