### PR TITLE
add cn and biz hostname validator tests

### DIFF
--- a/test/HostnameTest.php
+++ b/test/HostnameTest.php
@@ -635,4 +635,16 @@ class HostnameTest extends TestCase
         $validator = new Hostname();
         $this->assertTrue($validator->isValid('cafecafe.de'));
     }
+    
+    public function testValidCnHostname()
+    {
+        $validator = new Hostname();
+        $this->assertTrue($validator->isValid('google.cn'));
+    }
+    
+    public function testValidBizHostname()
+    {
+        $validator = new Hostname();
+        $this->assertTrue($validator->isValid('google.biz'));
+    }
 }


### PR DESCRIPTION
hi Team,

i noticed the red coverage badge on the readme and thought i'd help. ran a coverage report and saw that most of the interesting bits are already covered! almost all validators are at 90%+; great job!

i guess we're getting dinged by the large cn and biz TLD files that were probably extracted from the hostname validator. these two tests will replace that distracting red coverage badge with something a little more representative of the work you've accomplished here.