### PR TITLE
Ensure Between validator has both min and max values during construction

### DIFF
--- a/src/Between.php
+++ b/src/Between.php
@@ -90,15 +90,17 @@ class Between extends AbstractValidator
             $options = $temp;
         }
 
-        if (count($options) !== 2
-            && (! array_key_exists('min', $options) || ! array_key_exists('max', $options))
-        ) {
+        if (! array_key_exists('min', $options) || ! array_key_exists('max', $options)) {
             throw new Exception\InvalidArgumentException("Missing option: 'min' and 'max' have to be given");
         }
 
-        if (is_numeric($options['min']) && is_numeric($options['max'])) {
+        if ((isset($options['min']) && is_numeric($options['min']))
+            && (isset($options['max']) && is_numeric($options['max']))
+        ) {
             $this->numeric = true;
-        } elseif (is_string($options['min']) && is_string($options['max'])) {
+        } elseif ((isset($options['min']) && is_string($options['min']))
+            && (isset($options['max']) && is_string($options['max']))
+        ) {
             $this->numeric = false;
         } else {
             throw new Exception\InvalidArgumentException(

--- a/test/BetweenTest.php
+++ b/test/BetweenTest.php
@@ -265,21 +265,13 @@ class BetweenTest extends TestCase
     public function constructBetweenValidatorInvalidDataProvider()
     {
         return [
-            [
-                ['min' => 1],
-            ],
-            [
-                ['max' => 5],
-            ],
-            [
-                ['min' => 0, 'inclusive' => true],
-            ],
-            [
-                ['min' => 0, 'foo' => 'bar'],
-            ],
-            [
-                ['bar' => 'foo', 'foo' => 'bar'],
-            ],
+            'only-min'      => [['min' => 1]],
+            'only-max'      => [['max' => 5]],
+            'min-inclusive' => [['min' => 0, 'inclusive' => true]],
+            'max-inclusive' => [['max' => 5, 'inclusive' => true]],
+            'min-undefined' => [['min' => 0, 'foo' => 'bar']],
+            'max-undefined' => [['max' => 5, 'foo' => 'bar']],
+            'no-min-or-max' => [['bar' => 'foo', 'foo' => 'bar']],
         ];
     }
 


### PR DESCRIPTION
As noted in #125, and proved in #183, the `Between` validator had some erroneous logic for determining that both min and max values are provided during instantiation. This patch builds on the tests from #183, adding more tests, and providing a patch.

The fix is scheduled for 2.10.0, as it's a slight change in behavior, albeit to fix existing bad behavior.