### PR TITLE
ValidatorManager as alias instead of factory identifier

### DIFF
--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -9,9 +9,9 @@ namespace Zend\Validator;
 
 class ConfigProvider
 {
+
     /**
      * Return configuration for this component.
-     *
      * @return array
      */
     public function __invoke()
@@ -23,14 +23,16 @@ class ConfigProvider
 
     /**
      * Return dependency mappings for this component.
-     *
      * @return array
      */
     public function getDependencyConfig()
     {
         return [
             'factories' => [
-                'ValidatorManager' => ValidatorPluginManagerFactory::class,
+                ValidatorPluginManager::class => ValidatorPluginManagerFactory::class,
+            ],
+            'aliases' => [
+                'ValidatorManager' => ValidatorPluginManager::class,
             ],
         ];
     }

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -9,9 +9,9 @@ namespace Zend\Validator;
 
 class ConfigProvider
 {
-
     /**
      * Return configuration for this component.
+     *
      * @return array
      */
     public function __invoke()
@@ -23,6 +23,7 @@ class ConfigProvider
 
     /**
      * Return dependency mappings for this component.
+     *
      * @return array
      */
     public function getDependencyConfig()


### PR DESCRIPTION
As I like the usage of `ValidatorPluginManager::class` notation, I would prefer if services like the `ValidatorManager` will be able to get fetched by using `ValidatorPluginManager::class` aswell.

Is there any reason why we wont provide such ability?