### PR TITLE
Allow CreditCard Validator to be extended

### DIFF
--- a/src/CreditCard.php
+++ b/src/CreditCard.php
@@ -203,7 +203,7 @@ class CreditCard extends AbstractValidator
         }
 
         foreach ($type as $typ) {
-            if (defined('self::' . strtoupper($typ)) && ! in_array($typ, $this->options['type'])) {
+            if (defined('static::' . strtoupper($typ)) && ! in_array($typ, $this->options['type'])) {
                 $this->options['type'][] = $typ;
             }
 


### PR DESCRIPTION
In Brazil we have 2 other major credit card brands: Hipercard and Elo.

This change allow to extend the validator to add new Brands, this way: https://gist.github.com/stephandesouza/26b898e4df2d163ed3eeac183daa8e0b