### PR TITLE
CSRF shouldn't throw PHP errors when it receives non-string input

### DIFF
--- a/src/Csrf.php
+++ b/src/Csrf.php
@@ -116,7 +116,11 @@ class Csrf extends AbstractValidator
      */
     public function isValid($value, $context = null)
     {
-        $this->setValue((string) $value);
+        if (! is_string($value) ){
+            return false;    
+        }
+        
+        $this->setValue($value);
 
         $tokenId = $this->getTokenIdFromHash($value);
         $hash = $this->getValidationToken($tokenId);

--- a/test/CsrfTest.php
+++ b/test/CsrfTest.php
@@ -267,6 +267,11 @@ class CsrfTest extends TestCase
         $this->assertTrue($this->validator->isValid($bareToken));
     }
 
+    public function testCanRejectArrayValues()
+    {
+        $this->assertFalse($this->validator->isValid([]));
+    }
+
     public function fakeValuesDataProvider()
     {
         return [
@@ -277,7 +282,7 @@ class CsrfTest extends TestCase
             ['fakeTokenId'],
             [md5(uniqid()) . '-'],
             [md5(uniqid()) . '-' . md5(uniqid())],
-            ['-' . md5(uniqid())]
+            ['-' . md5(uniqid())],
         ];
     }
 


### PR DESCRIPTION
The CSRF is a bit naive, assuming that it is receiving a string, and not an array.  Most penetration tests start with malformed input, and arrays cause this validator to throw an Array to string conversion error.

Reproducing the problem is simple.  Craft a form that includes a CSRF Filter, and modify your post to send CSRF as an array.  e.g.,

```
POST /login HTTP/1.1 Content-Length: 142 Content-Type: application/x-www-form-urlencoded Referer: http://foo.com Cookie: PHPSESSID=s3r0icn96iqstvsrpkae3n2sta; lastRoute=register; locale=en_US; lastPageVisited=http://foo.com/login; __cfduid=d815a2363ab50c616e80627e0ca5834a81516720789 Host: foo.com
Connection: Keep-alive Accept-Encoding: gzip,deflate User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko Accept: */* axis=1&csrf[]=576ae4642376a2904866a504f395c75ab04205df5b1df8e0bbd999f6e6746c73&email=sample%40email.tst&password=g00dPa%24%24w0rD&remember=on
```

The CSRF filter should report a validation failure when an array is pushed in, and not crap out.