### PR TITLE
issue#27 - Tidy some misplaced unit tests

### DIFF
--- a/test/AbstractTest.php
+++ b/test/AbstractTest.php
@@ -65,11 +65,6 @@ class AbstractTest extends TestCase
         $this->assertNull($this->validator->getTranslator());
     }
 
-    public function testGlobalDefaultTranslatorNullByDefault()
-    {
-        $this->assertNull(AbstractValidator::getDefaultTranslator());
-    }
-
     public function testErrorMessagesAreTranslatedWhenTranslatorPresent()
     {
         if (! extension_loaded('intl')) {

--- a/test/StaticValidatorTest.php
+++ b/test/StaticValidatorTest.php
@@ -10,12 +10,13 @@
 namespace ZendTest\Validator;
 
 use PHPUnit\Framework\TestCase;
-use Zend\Validator\AbstractValidator;
 use Zend\I18n\Validator\Alpha;
-use Zend\Validator\Between;
-use Zend\Validator\StaticValidator;
-use Zend\Validator\ValidatorPluginManager;
+use Zend\ServiceManager\Exception\ServiceNotFoundException;
 use Zend\ServiceManager\ServiceManager;
+use Zend\Validator\AbstractValidator;
+use Zend\Validator\Between;
+use Zend\Validator\ValidatorPluginManager;
+use Zend\Validator\StaticValidator;
 
 /**
  * @group      Zend_Validator
@@ -166,5 +167,20 @@ class StaticValidatorTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('options');
         StaticValidator::execute($value, $validator, $options);
+    }
+
+    /**
+     * Ensures that if we specify a validator class basename that doesn't
+     * exist in the namespace, is() throws an exception.
+     *
+     * Refactored to conform with ZF-2724.
+     *
+     * @group  ZF-2724
+     * @return void
+     */
+    public function testStaticFactoryClassNotFound()
+    {
+        $this->expectException(ServiceNotFoundException::class);
+        StaticValidator::execute('1234', 'UnknownValidator');
     }
 }

--- a/test/ValidatorChainTest.php
+++ b/test/ValidatorChainTest.php
@@ -15,7 +15,6 @@ use Zend\Validator\Between;
 use Zend\Validator\NotEmpty;
 use Zend\Validator\StaticValidator;
 use Zend\Validator\ValidatorChain;
-use Zend\ServiceManager\Exception\ServiceNotFoundException;
 use Zend\Validator\ValidatorInterface;
 use Zend\Validator\GreaterThan;
 
@@ -98,39 +97,6 @@ class ValidatorChainTest extends TestCase
             ->attach($this->getValidatorFalse());
         $this->assertFalse($this->validator->isValid(null));
         $this->assertEquals(['error' => 'validation failed'], $this->validator->getMessages());
-    }
-
-    /**
-     * Ensures that if we specify a validator class basename that doesn't
-     * exist in the namespace, is() throws an exception.
-     *
-     * Refactored to conform with ZF-2724.
-     *
-     * @group  ZF-2724
-     * @return void
-     */
-    public function testStaticFactoryClassNotFound()
-    {
-        $this->expectException(ServiceNotFoundException::class);
-        StaticValidator::execute('1234', 'UnknownValidator');
-    }
-
-    public function testSetGetMessageLengthLimitation()
-    {
-        AbstractValidator::setMessageLength(5);
-        $this->assertEquals(5, AbstractValidator::getMessageLength());
-
-        $valid = new Between(1, 10);
-        $this->assertFalse($valid->isValid(24));
-        $message = current($valid->getMessages());
-        $this->assertLessThanOrEqual(5, strlen($message));
-    }
-
-    public function testSetGetDefaultTranslator()
-    {
-        $translator = new TestAsset\Translator();
-        AbstractValidator::setDefaultTranslator($translator);
-        $this->assertSame($translator, AbstractValidator::getDefaultTranslator());
     }
 
     public function testAllowsPrependingValidators()


### PR DESCRIPTION
Fix #27 
ValidatorChainTest::testIsValidWithParameters() has already been removed.

ValidatorChainTest::testStaticFactoryClassNotFound() still exist and was moved to StaticValidatorTest.

ValidatorChainTest::testSetGetMessageLengthLimitation() still exist but was removed since StaticValidatorTest::testMaximumErrorMessageLength() test the same behavior.

ValidatorChainTest::testSetGetDefaultTranslator() still exist but was removed along AbstractTest::testGlobalDefaultTranslatorNullByDefault() since the sale behavior is already tested by AbstractTest::testDefaultTranslatorMethods().
