### PR TITLE
Correcting validation error

### DIFF
--- a/src/File/Hash.php
+++ b/src/File/Hash.php
@@ -163,7 +163,7 @@ class Hash extends AbstractValidator
             }
 
             foreach ($hashes as $hash) {
-                if ($filehash == $hash) {
+                if ($filehash === $hash) {
                     return true;
                 }
             }

--- a/src/File/Hash.php
+++ b/src/File/Hash.php
@@ -163,7 +163,7 @@ class Hash extends AbstractValidator
             }
 
             foreach ($hashes as $hash) {
-                if ($filehash === $hash) {
+                if ($filehash == $hash) {
                     return true;
                 }
             }

--- a/src/File/Hash.php
+++ b/src/File/Hash.php
@@ -114,6 +114,12 @@ class Hash extends AbstractValidator
         }
 
         foreach ($options as $value) {
+            if (! is_string($value)) {
+                throw new Exception\InvalidArgumentException(sprintf(
+                    'Hash must be a string, %s received',
+                    is_object($value) ? get_class($value) : gettype($value)
+                ));
+            }
             $this->options['hash'][$value] = $algorithm;
         }
 

--- a/test/File/HashTest.php
+++ b/test/File/HashTest.php
@@ -239,4 +239,18 @@ class HashTest extends TestCase
         $options = $r->getValue($validator);
         $this->assertSame($algorithm, $options['algorithm']);
     }
+
+    /**
+     * @dataProvider invalidHashTypes
+     *
+     * @param mixed $hash
+     */
+    public function testInvalidHashProvidedInArrayFormat($hash)
+    {
+        $validator = new File\Hash('12345');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Hash must be a string');
+        $validator->addHash([$hash]);
+    }
 }


### PR DESCRIPTION
Sometimes there is a problem with validation - when generated hash is valid integer (includes only digits - it rarely happens) - php converts that string to integer - then you get integer in array of hashes ($hashes). Comparing that integer to returned string from hash_file function results in false value while hash is the same but differs in variable type.