### PR TITLE
Update validator-chains.md

### DIFF
--- a/doc/book/validator-chains.md
+++ b/doc/book/validator-chains.md
@@ -43,7 +43,7 @@ written as follows, then the alphanumeric validation would not occur if the
 string length validation fails:
 
 ```php
-$chain->attach(new StringLength(['min' => 6, 'max' => 12], true));
+$chain->attach(new StringLength(['min' => 6, 'max' => 12]), true);
 $chain->attach(new Alnum());
 ```
 


### PR DESCRIPTION
The flag for `$breakChainOnFailure` should be second parameter to `attach` method, not `StringLength`.