### PR TITLE
PSR-7 file validation implemented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Changed
 
-- Nothing.
+- [#251](https://github.com/zendframework/zend-validator/pull/251) updates the logic of each of the various `Zend\Validator\File` validators
+  to allow validating against PSR-7 `UploadedFileInterface` instances, expanding
+  the support originally provided in version 2.11.0.
 
 ### Deprecated
 
@@ -19,7 +21,6 @@ All notable changes to this project will be documented in this file, in reverse 
 ### Removed
 
 - [#250](https://github.com/zendframework/zend-validator/pull/250) removes support for zend-stdlib v2 releases.
-
 
 ### Fixed
 

--- a/src/File/Crc32.php
+++ b/src/File/Crc32.php
@@ -9,13 +9,15 @@
 
 namespace Zend\Validator\File;
 
-use Zend\Validator\Exception;
+use Zend\Validator\File\FileInformationTrait;
 
 /**
  * Validator for the crc32 hash of given files
  */
 class Crc32 extends Hash
 {
+    use FileInformationTrait;
+
     /**
      * @const string Error constants
      */
@@ -85,32 +87,18 @@ class Crc32 extends Hash
      */
     public function isValid($value, $file = null)
     {
-        if (is_string($value) && is_array($file)) {
-            // Legacy Zend\Transfer API support
-            $filename = $file['name'];
-            $file     = $file['tmp_name'];
-        } elseif (is_array($value)) {
-            if (! isset($value['tmp_name']) || ! isset($value['name'])) {
-                throw new Exception\InvalidArgumentException(
-                    'Value array must be in $_FILES format'
-                );
-            }
-            $file     = $value['tmp_name'];
-            $filename = $value['name'];
-        } else {
-            $file     = $value;
-            $filename = basename($file);
-        }
-        $this->setValue($filename);
+        $fileInfo = $this->getFileInfo($value, $file);
+
+        $this->setValue($fileInfo['filename']);
 
         // Is file readable ?
-        if (empty($file) || false === is_readable($file)) {
+        if (empty($fileInfo['file']) || false === is_readable($fileInfo['file'])) {
             $this->error(self::NOT_FOUND);
             return false;
         }
 
         $hashes   = array_unique(array_keys($this->getHash()));
-        $filehash = hash_file('crc32', $file);
+        $filehash = hash_file('crc32', $fileInfo['file']);
         if ($filehash === false) {
             $this->error(self::NOT_DETECTED);
             return false;

--- a/src/File/FileInformationTrait.php
+++ b/src/File/FileInformationTrait.php
@@ -64,7 +64,7 @@ trait FileInformationTrait
             $fileInfo['basename'] = basename($fileInfo['file']);
         }
 
-        if (! $hasType) {
+        if ($hasType) {
             $fileInfo['filetype'] = $file['type'];
         }
 
@@ -99,7 +99,7 @@ trait FileInformationTrait
             $fileInfo['basename'] = basename($fileInfo['file']);
         }
 
-        if (! $hasType) {
+        if ($hasType) {
             $fileInfo['filetype'] = $file['type'];
         }
 
@@ -128,7 +128,7 @@ trait FileInformationTrait
             $fileInfo['basename'] = basename($fileInfo['file']);
         }
 
-        if (! $hasType) {
+        if ($hasType) {
             $fileInfo['filetype'] = $file->getClientMediaType();
         }
 
@@ -157,7 +157,7 @@ trait FileInformationTrait
             $fileInfo['basename'] = basename($fileInfo['file']);
         }
 
-        if (! $hasType) {
+        if ($hasType) {
             $fileInfo['filetype'] = null;
         }
 

--- a/src/File/FileInformationTrait.php
+++ b/src/File/FileInformationTrait.php
@@ -24,8 +24,8 @@ trait FileInformationTrait
     protected function getFileInfo(
         $value,
         $file = null,
-        bool $hasType = false,
-        bool $hasBasename = false
+        $hasType = false,
+        $hasBasename = false
     ) {
         if (is_string($value) && is_array($file)) {
             return $this->getLegacyFileInfo($file, $hasType, $hasBasename);
@@ -52,8 +52,8 @@ trait FileInformationTrait
      */
     private function getLegacyFileInfo(
         $file,
-        bool $hasType = false,
-        bool $hasBasename = false
+        $hasType = false,
+        $hasBasename = false
     ) {
         $fileInfo = [];
 
@@ -80,9 +80,9 @@ trait FileInformationTrait
      * @return array
      */
     private function getSapiFileInfo(
-        array $file,
-        bool $hasType = false,
-        bool $hasBasename = false
+        $file,
+        $hasType = false,
+        $hasBasename = false
     ) {
         if (! isset($file['tmp_name']) || ! isset($file['name'])) {
             throw new Exception\InvalidArgumentException(
@@ -115,9 +115,9 @@ trait FileInformationTrait
      * @return array
      */
     private function getPsr7FileInfo(
-        UploadedFileInterface $file,
-        bool $hasType = false,
-        bool $hasBasename = false
+        $file,
+        $hasType = false,
+        $hasBasename = false
     ) {
         $fileInfo = [];
 
@@ -144,9 +144,9 @@ trait FileInformationTrait
      * @return array
      */
     private function getFileBasedFileInfo(
-        string $file,
-        bool $hasType = false,
-        bool $hasBasename = false
+        $file,
+        $hasType = false,
+        $hasBasename = false
     ) {
         $fileInfo = [];
 

--- a/src/File/FileInformationTrait.php
+++ b/src/File/FileInformationTrait.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-validator for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-validator/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Validator\File;
+
+use Psr\Http\Message\UploadedFileInterface;
+use Zend\Validator\Exception;
+
+trait FileInformationTrait
+{
+    /**
+     * Returns array if the procedure is identified
+     *
+     * @param  string|array|object $value    Filename to check
+     * @param  array               $file     File data from \Zend\File\Transfer\Transfer (optional)
+     * @param  bool                $hasType  Return with filetype (optional)
+     * @param  bool                $basename Return with basename - is calculated from location path (optional)
+     * @return array
+     */
+    protected function getFileInfo(
+        $value,
+        $file = null,
+        bool $hasType = false,
+        bool $hasBasename = false
+    ) {
+        if (is_string($value) && is_array($file)) {
+            return $this->getLegacyFileInfo($file, $hasType, $hasBasename);
+        }
+
+        if (is_array($value)) {
+            return $this->getSapiFileInfo($value, $hasType, $hasBasename);
+        }
+
+        if ($value instanceof UploadedFileInterface) {
+            return $this->getPsr7FileInfo($value, $hasType, $hasBasename);
+        }
+
+        return $this->getFileBasedFileInfo($value, $hasType, $hasBasename);
+    }
+
+    /**
+     * Generate file information array with Legacy Zend\Transfer API
+     *
+     * @param object $file        File data from \Zend\File\Transfer\Transfer
+     * @param bool   $hasType     Return with filetype
+     * @param bool   $hasBasename Basename is calculated from location path
+     * @return array
+     */
+    private function getLegacyFileInfo(
+        $file,
+        bool $hasType = false,
+        bool $hasBasename = false
+    ) {
+        $fileInfo = [];
+
+        $fileInfo['filename'] = $file['name'];
+        $fileInfo['file']     = $file['tmp_name'];
+
+        if ($hasBasename) {
+            $fileInfo['basename'] = basename($fileInfo['file']);
+        }
+
+        if (! $hasType) {
+            $fileInfo['filetype'] = $file['type'];
+        }
+
+        return $fileInfo;
+    }
+
+    /**
+     * Generate file information array with Sapi
+     *
+     * @param array $file        File data from Sapi
+     * @param bool  $hasType     Return with filetype
+     * @param bool  $hasBasename Filename is calculated from location path
+     * @return array
+     */
+    private function getSapiFileInfo(
+        array $file,
+        bool $hasType = false,
+        bool $hasBasename = false
+    ) {
+        if (! isset($file['tmp_name']) || ! isset($file['name'])) {
+            throw new Exception\InvalidArgumentException(
+                'Value array must be in $_FILES format'
+            );
+        }
+
+        $fileInfo = [];
+
+        $fileInfo['file']     = $file['tmp_name'];
+        $fileInfo['filename'] = $file['name'];
+
+        if ($hasBasename) {
+            $fileInfo['basename'] = basename($fileInfo['file']);
+        }
+
+        if (! $hasType) {
+            $fileInfo['filetype'] = $file['type'];
+        }
+
+        return $fileInfo;
+    }
+
+    /**
+     * Generate file information array with PSR-7 UploadedFileInterface
+     *
+     * @param object $file        File data from Psr\Http\Message\UploadedFileInterface
+     * @param bool   $hasType     Return with filetype
+     * @param bool   $hasBasename Filename is calculated from location path
+     * @return array
+     */
+    private function getPsr7FileInfo(
+        UploadedFileInterface $file,
+        bool $hasType = false,
+        bool $hasBasename = false
+    ) {
+        $fileInfo = [];
+
+        $fileInfo['file']     = $file->getStream()->getMetadata('uri');
+        $fileInfo['filename'] = $file->getClientFilename();
+
+        if ($hasBasename) {
+            $fileInfo['basename'] = basename($fileInfo['file']);
+        }
+
+        if (! $hasType) {
+            $fileInfo['filetype'] = $file->getClientMediaType();
+        }
+
+        return $fileInfo;
+    }
+
+    /**
+     * Generate file information array with base method
+     *
+     * @param string $file        File path
+     * @param bool   $hasType     Return with filetype
+     * @param bool   $hasBasename Filename is calculated from location path
+     * @return array
+     */
+    private function getFileBasedFileInfo(
+        string $file,
+        bool $hasType = false,
+        bool $hasBasename = false
+    ) {
+        $fileInfo = [];
+
+        $fileInfo['file']     = $file;
+        $fileInfo['filename'] = basename($fileInfo['file']);
+
+        if ($hasBasename) {
+            $fileInfo['basename'] = basename($fileInfo['file']);
+        }
+
+        if (! $hasType) {
+            $fileInfo['filetype'] = null;
+        }
+
+        return $fileInfo;
+    }
+}

--- a/src/File/FileInformationTrait.php
+++ b/src/File/FileInformationTrait.php
@@ -16,14 +16,14 @@ trait FileInformationTrait
      * Returns array if the procedure is identified
      *
      * @param  string|array|object $value    Filename to check
-     * @param  array               $file     File data from \Zend\File\Transfer\Transfer (optional)
+     * @param  null|array          $file     File data (when using legacy Zend_File_Transfer API)
      * @param  bool                $hasType  Return with filetype (optional)
      * @param  bool                $basename Return with basename - is calculated from location path (optional)
      * @return array
      */
     protected function getFileInfo(
         $value,
-        $file = null,
+        array $file = null,
         $hasType = false,
         $hasBasename = false
     ) {
@@ -43,15 +43,15 @@ trait FileInformationTrait
     }
 
     /**
-     * Generate file information array with Legacy Zend\Transfer API
+     * Generate file information array with legacy Zend_File_Transfer API
      *
-     * @param object $file        File data from \Zend\File\Transfer\Transfer
+     * @param array  $file        File data
      * @param bool   $hasType     Return with filetype
      * @param bool   $hasBasename Basename is calculated from location path
      * @return array
      */
     private function getLegacyFileInfo(
-        $file,
+        array $file,
         $hasType = false,
         $hasBasename = false
     ) {
@@ -72,15 +72,15 @@ trait FileInformationTrait
     }
 
     /**
-     * Generate file information array with Sapi
+     * Generate file information array with SAPI
      *
-     * @param array $file        File data from Sapi
+     * @param array $file        File data from SAPI
      * @param bool  $hasType     Return with filetype
      * @param bool  $hasBasename Filename is calculated from location path
      * @return array
      */
     private function getSapiFileInfo(
-        $file,
+        array $file,
         $hasType = false,
         $hasBasename = false
     ) {
@@ -109,13 +109,13 @@ trait FileInformationTrait
     /**
      * Generate file information array with PSR-7 UploadedFileInterface
      *
-     * @param object $file        File data from Psr\Http\Message\UploadedFileInterface
-     * @param bool   $hasType     Return with filetype
-     * @param bool   $hasBasename Filename is calculated from location path
+     * @param UploadedFileInterface $file
+     * @param bool                  $hasType     Return with filetype
+     * @param bool                  $hasBasename Filename is calculated from location path
      * @return array
      */
     private function getPsr7FileInfo(
-        $file,
+        UploadedFileInterface $file,
         $hasType = false,
         $hasBasename = false
     ) {

--- a/src/File/ImageSize.php
+++ b/src/File/ImageSize.php
@@ -12,12 +12,15 @@ namespace Zend\Validator\File;
 use Zend\Stdlib\ErrorHandler;
 use Zend\Validator\AbstractValidator;
 use Zend\Validator\Exception;
+use Zend\Validator\File\FileInformationTrait;
 
 /**
  * Validator for the image size of an image file
  */
 class ImageSize extends AbstractValidator
 {
+    use FileInformationTrait;
+
     /**
      * @const string Error constants
      */
@@ -332,32 +335,18 @@ class ImageSize extends AbstractValidator
      */
     public function isValid($value, $file = null)
     {
-        if (is_string($value) && is_array($file)) {
-            // Legacy Zend\Transfer API support
-            $filename = $file['name'];
-            $file     = $file['tmp_name'];
-        } elseif (is_array($value)) {
-            if (! isset($value['tmp_name']) || ! isset($value['name'])) {
-                throw new Exception\InvalidArgumentException(
-                    'Value array must be in $_FILES format'
-                );
-            }
-            $file     = $value['tmp_name'];
-            $filename = $value['name'];
-        } else {
-            $file     = $value;
-            $filename = basename($file);
-        }
-        $this->setValue($filename);
+        $fileInfo = $this->getFileInfo($value, $file);
+
+        $this->setValue($fileInfo['filename']);
 
         // Is file readable ?
-        if (empty($file) || false === is_readable($file)) {
+        if (empty($fileInfo['file']) || false === is_readable($fileInfo['file'])) {
             $this->error(self::NOT_READABLE);
             return false;
         }
 
         ErrorHandler::start();
-        $size = getimagesize($file);
+        $size = getimagesize($fileInfo['file']);
         ErrorHandler::stop();
 
         if (empty($size) || ($size[0] === 0) || ($size[1] === 0)) {

--- a/src/File/MimeType.php
+++ b/src/File/MimeType.php
@@ -14,12 +14,15 @@ use Zend\Stdlib\ArrayUtils;
 use Zend\Stdlib\ErrorHandler;
 use Zend\Validator\AbstractValidator;
 use Zend\Validator\Exception;
+use Zend\Validator\File\FileInformationTrait;
 
 /**
  * Validator for the mime type of a file
  */
 class MimeType extends AbstractValidator
 {
+    use FileInformationTrait;
+
     /**#@+
      * @const Error type constants
      */
@@ -341,29 +344,12 @@ class MimeType extends AbstractValidator
      */
     public function isValid($value, $file = null)
     {
-        if (is_string($value) && is_array($file)) {
-            // Legacy Zend\Transfer API support
-            $filename = $file['name'];
-            $filetype = $file['type'];
-            $file     = $file['tmp_name'];
-        } elseif (is_array($value)) {
-            if (! isset($value['tmp_name']) || ! isset($value['name']) || ! isset($value['type'])) {
-                throw new Exception\InvalidArgumentException(
-                    'Value array must be in $_FILES format'
-                );
-            }
-            $file     = $value['tmp_name'];
-            $filename = $value['name'];
-            $filetype = $value['type'];
-        } else {
-            $file     = $value;
-            $filename = basename($file);
-            $filetype = null;
-        }
-        $this->setValue($filename);
+        $fileInfo = $this->getFileInfo($value, $file, true);
+
+        $this->setValue($fileInfo['filename']);
 
         // Is file readable ?
-        if (empty($file) || false === is_readable($file)) {
+        if (empty($fileInfo['file']) || false === is_readable($fileInfo['file'])) {
             $this->error(static::NOT_READABLE);
             return false;
         }
@@ -384,13 +370,13 @@ class MimeType extends AbstractValidator
 
             $this->type = null;
             if (! empty($this->finfo)) {
-                $this->type = finfo_file($this->finfo, $file);
+                $this->type = finfo_file($this->finfo, $fileInfo['file']);
                 unset($this->finfo);
             }
         }
 
         if (empty($this->type) && $this->getHeaderCheck()) {
-            $this->type = $filetype;
+            $this->type = $fileInfo['filetype'];
         }
 
         if (empty($this->type)) {

--- a/src/File/NotExists.php
+++ b/src/File/NotExists.php
@@ -10,12 +10,15 @@
 namespace Zend\Validator\File;
 
 use Zend\Validator\Exception;
+use Zend\Validator\File\FileInformationTrait;
 
 /**
  * Validator which checks if the destination file does not exist
  */
 class NotExists extends Exists
 {
+    use FileInformationTrait;
+
     /**
      * @const string Error constants
      */
@@ -37,31 +40,15 @@ class NotExists extends Exists
      */
     public function isValid($value, $file = null)
     {
-        if (is_string($value) && is_array($file)) {
-            // Legacy Zend\Transfer API support
-            $filename = $file['name'];
-            $file     = $file['tmp_name'];
-            $this->setValue($filename);
-        } elseif (is_array($value)) {
-            if (! isset($value['tmp_name']) || ! isset($value['name'])) {
-                throw new Exception\InvalidArgumentException(
-                    'Value array must be in $_FILES format'
-                );
-            }
-            $file     = $value['tmp_name'];
-            $filename = basename($file);
-            $this->setValue($value['name']);
-        } else {
-            $file     = $value;
-            $filename = basename($file);
-            $this->setValue($filename);
-        }
+        $fileInfo = $this->getFileInfo($value, $file, false, true);
+
+        $this->setValue($fileInfo['filename']);
 
         $check = false;
         $directories = $this->getDirectory(true);
         if (! isset($directories)) {
             $check = true;
-            if (file_exists($file)) {
+            if (file_exists($fileInfo['file'])) {
                 $this->error(self::DOES_EXIST);
                 return false;
             }
@@ -72,7 +59,7 @@ class NotExists extends Exists
                 }
 
                 $check = true;
-                if (file_exists($directory . DIRECTORY_SEPARATOR . $filename)) {
+                if (file_exists($directory . DIRECTORY_SEPARATOR . $fileInfo['basename'])) {
                     $this->error(self::DOES_EXIST);
                     return false;
                 }

--- a/src/File/Sha1.php
+++ b/src/File/Sha1.php
@@ -9,13 +9,15 @@
 
 namespace Zend\Validator\File;
 
-use Zend\Validator\Exception;
+use Zend\Validator\File\FileInformationTrait;
 
 /**
  * Validator for the sha1 hash of given files
  */
 class Sha1 extends Hash
 {
+    use FileInformationTrait;
+
     /**
      * @const string Error constants
      */
@@ -85,32 +87,18 @@ class Sha1 extends Hash
      */
     public function isValid($value, $file = null)
     {
-        if (is_string($value) && is_array($file)) {
-            // Legacy Zend\Transfer API support
-            $filename = $file['name'];
-            $file     = $file['tmp_name'];
-        } elseif (is_array($value)) {
-            if (! isset($value['tmp_name']) || ! isset($value['name'])) {
-                throw new Exception\InvalidArgumentException(
-                    'Value array must be in $_FILES format'
-                );
-            }
-            $file     = $value['tmp_name'];
-            $filename = $value['name'];
-        } else {
-            $file     = $value;
-            $filename = basename($file);
-        }
-        $this->setValue($filename);
+        $fileInfo = $this->getFileInfo($value, $file);
+
+        $this->setValue($fileInfo['filename']);
 
         // Is file readable ?
-        if (empty($file) || false === is_readable($file)) {
+        if (empty($fileInfo['file']) || false === is_readable($fileInfo['file'])) {
             $this->error(self::NOT_FOUND);
             return false;
         }
 
         $hashes   = array_unique(array_keys($this->getHash()));
-        $filehash = hash_file('sha1', $file);
+        $filehash = hash_file('sha1', $fileInfo['file']);
         if ($filehash === false) {
             $this->error(self::NOT_DETECTED);
             return false;

--- a/src/File/Size.php
+++ b/src/File/Size.php
@@ -12,12 +12,15 @@ namespace Zend\Validator\File;
 use Zend\Stdlib\ErrorHandler;
 use Zend\Validator\AbstractValidator;
 use Zend\Validator\Exception;
+use Zend\Validator\File\FileInformationTrait;
 
 /**
  * Validator for the maximum size of a file up to a max of 2GB
  */
 class Size extends AbstractValidator
 {
+    use FileInformationTrait;
+
     /**
      * @const string Error constants
      */
@@ -234,33 +237,19 @@ class Size extends AbstractValidator
      */
     public function isValid($value, $file = null)
     {
-        if (is_string($value) && is_array($file)) {
-            // Legacy Zend\Transfer API support
-            $filename = $file['name'];
-            $file     = $file['tmp_name'];
-        } elseif (is_array($value)) {
-            if (! isset($value['tmp_name']) || ! isset($value['name'])) {
-                throw new Exception\InvalidArgumentException(
-                    'Value array must be in $_FILES format'
-                );
-            }
-            $file     = $value['tmp_name'];
-            $filename = $value['name'];
-        } else {
-            $file     = $value;
-            $filename = basename($file);
-        }
-        $this->setValue($filename);
+        $fileInfo = $this->getFileInfo($value, $file);
+
+        $this->setValue($fileInfo['filename']);
 
         // Is file readable ?
-        if (empty($file) || false === is_readable($file)) {
+        if (empty($fileInfo['file']) || false === is_readable($fileInfo['file'])) {
             $this->error(self::NOT_FOUND);
             return false;
         }
 
         // limited to 4GB files
         ErrorHandler::start();
-        $size = sprintf("%u", filesize($file));
+        $size = sprintf("%u", filesize($fileInfo['file']));
         ErrorHandler::stop();
         $this->size = $size;
 

--- a/src/File/WordCount.php
+++ b/src/File/WordCount.php
@@ -11,12 +11,15 @@ namespace Zend\Validator\File;
 
 use Zend\Validator\AbstractValidator;
 use Zend\Validator\Exception;
+use Zend\Validator\File\FileInformationTrait;
 
 /**
  * Validator for counting all words in a file
  */
 class WordCount extends AbstractValidator
 {
+    use FileInformationTrait;
+
     /**
      * @const string Error constants
      */
@@ -175,31 +178,17 @@ class WordCount extends AbstractValidator
      */
     public function isValid($value, $file = null)
     {
-        if (is_string($value) && is_array($file)) {
-            // Legacy Zend\Transfer API support
-            $filename = $file['name'];
-            $file     = $file['tmp_name'];
-        } elseif (is_array($value)) {
-            if (! isset($value['tmp_name']) || ! isset($value['name'])) {
-                throw new Exception\InvalidArgumentException(
-                    'Value array must be in $_FILES format'
-                );
-            }
-            $file     = $value['tmp_name'];
-            $filename = $value['name'];
-        } else {
-            $file     = $value;
-            $filename = basename($file);
-        }
-        $this->setValue($filename);
+        $fileInfo = $this->getFileInfo($value, $file);
+
+        $this->setValue($fileInfo['filename']);
 
         // Is file readable ?
-        if (empty($file) || false === is_readable($file)) {
+        if (empty($fileInfo['file']) || false === is_readable($fileInfo['file'])) {
             $this->error(self::NOT_FOUND);
             return false;
         }
 
-        $content     = file_get_contents($file);
+        $content     = file_get_contents($fileInfo['file']);
         $this->count = str_word_count($content);
         if (($this->getMax() !== null) && ($this->count > $this->getMax())) {
             $this->error(self::TOO_MUCH);

--- a/test/File/FileInformationTraitTest.php
+++ b/test/File/FileInformationTraitTest.php
@@ -1,0 +1,286 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-validator for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-validator/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Validator\File;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UploadedFileInterface;
+use ZendTest\Validator\File\TestAsset\FileInformation;
+use Zend\Validator\Exception\InvalidArgumentException;
+
+/**
+ * @group      Zend_Validator
+ */
+class FileInformationTraitTest extends TestCase
+{
+    /** @var ObjectProphecy */
+    public $stream;
+
+    /** @var ObjectProphecy */
+    public $upload;
+
+    public function setUp()
+    {
+        $this->stream = $this->prophesize(StreamInterface::class);
+        $this->upload = $this->prophesize(UploadedFileInterface::class);
+    }
+
+    public function testLegacyFileInfoBasic()
+    {
+        $testFile = __DIR__ . '/_files/testsize.mo';
+        $basename = basename($testFile);
+        $file = [
+          'name'     => $basename,
+          'tmp_name' => $testFile
+        ];
+
+        $fileInformation = new FileInformation();
+        $fileInfo = $fileInformation->checkFileInformation(
+            $basename,
+            $file
+        );
+
+        $this->assertEquals($fileInfo, [
+          'filename' => $file['name'],
+          'file'     => $file['tmp_name'],
+        ]);
+    }
+
+    public function testLegacyFileInfoWithFiletype()
+    {
+        $testFile = __DIR__ . '/_files/testsize.mo';
+        $basename = basename($testFile);
+        $file = [
+          'name'     => $basename,
+          'tmp_name' => $testFile,
+          'type' => 'mo',
+        ];
+
+        $fileInformation = new FileInformation();
+        $fileInfo = $fileInformation->checkFileInformation(
+            $basename,
+            $file,
+            true
+        );
+
+        $this->assertEquals($fileInfo, [
+          'filename' => $file['name'],
+          'file'     => $file['tmp_name'],
+          'filetype' => $file['type'],
+        ]);
+    }
+
+    public function testLegacyFileInfoWithBasename()
+    {
+        $testFile = __DIR__ . '/_files/testsize.mo';
+        $basename = basename($testFile);
+        $file = [
+          'name'     => $basename,
+          'tmp_name' => $testFile,
+        ];
+
+        $fileInformation = new FileInformation();
+        $fileInfo = $fileInformation->checkFileInformation(
+            $basename,
+            $file,
+            false,
+            true
+        );
+
+        $this->assertEquals($fileInfo, [
+          'filename' => $file['name'],
+          'file'     => $file['tmp_name'],
+          'basename' => basename($file['tmp_name']),
+        ]);
+    }
+
+    public function testSapiFileInfoBasic()
+    {
+        $testFile = __DIR__ . '/_files/testsize.mo';
+        $file = [
+          'name'     => basename($testFile),
+          'tmp_name' => $testFile
+        ];
+
+        $fileInformation = new FileInformation();
+        $fileInfo = $fileInformation->checkFileInformation(
+            $file
+        );
+
+        $this->assertEquals($fileInfo, [
+          'filename' => $file['name'],
+          'file'     => $file['tmp_name'],
+        ]);
+    }
+
+    public function testSapiFileInfoWithFiletype()
+    {
+        $testFile = __DIR__ . '/_files/testsize.mo';
+        $file = [
+          'name'     => basename($testFile),
+          'tmp_name' => $testFile,
+          'type'     => 'mo',
+        ];
+
+        $fileInformation = new FileInformation();
+        $fileInfo = $fileInformation->checkFileInformation(
+            $file,
+            null,
+            true
+        );
+
+        $this->assertEquals($fileInfo, [
+          'filename' => $file['name'],
+          'file'     => $file['tmp_name'],
+          'filetype' => $file['type'],
+        ]);
+    }
+
+    public function testSapiFileInfoWithBasename()
+    {
+        $testFile = __DIR__ . '/_files/testsize.mo';
+        $file = [
+          'name'     => basename($testFile),
+          'tmp_name' => $testFile,
+        ];
+
+        $fileInformation = new FileInformation();
+        $fileInfo = $fileInformation->checkFileInformation(
+            $file,
+            null,
+            false,
+            true
+        );
+
+        $this->assertEquals($fileInfo, [
+          'filename' => $file['name'],
+          'file'     => $file['tmp_name'],
+          'basename' => basename($file['tmp_name']),
+        ]);
+    }
+
+    public function testPsr7FileInfoBasic()
+    {
+        $testFile = __DIR__ . '/_files/testsize.mo';
+
+        $this->stream->getMetadata('uri')->willReturn($testFile);
+        $this->upload->getClientFilename()->willReturn(basename($testFile));
+        $this->upload->getClientMediaType()->willReturn(mime_content_type($testFile));
+        $this->upload->getStream()->willReturn($this->stream->reveal());
+
+        $fileInformation = new FileInformation();
+        $fileInfo = $fileInformation->checkFileInformation(
+            $this->upload->reveal()
+        );
+
+        $this->assertEquals($fileInfo, [
+          'filename' => basename($testFile),
+          'file'     => $testFile,
+        ]);
+    }
+
+    public function testPsr7FileInfoBasicWithFiletype()
+    {
+        $testFile = __DIR__ . '/_files/testsize.mo';
+
+        $this->stream->getMetadata('uri')->willReturn($testFile);
+        $this->upload->getClientFilename()->willReturn(basename($testFile));
+        $this->upload->getClientMediaType()->willReturn(mime_content_type($testFile));
+        $this->upload->getStream()->willReturn($this->stream->reveal());
+
+        $fileInformation = new FileInformation();
+        $fileInfo = $fileInformation->checkFileInformation(
+            $this->upload->reveal(),
+            null,
+            true
+        );
+
+        $this->assertEquals($fileInfo, [
+          'filename' => basename($testFile),
+          'file'     => $testFile,
+          'filetype' => mime_content_type($testFile),
+        ]);
+    }
+
+    public function testPsr7FileInfoBasicWithBasename()
+    {
+        $testFile = __DIR__ . '/_files/testsize.mo';
+
+        $this->stream->getMetadata('uri')->willReturn($testFile);
+        $this->upload->getClientFilename()->willReturn(basename($testFile));
+        $this->upload->getClientMediaType()->willReturn(mime_content_type($testFile));
+        $this->upload->getStream()->willReturn($this->stream->reveal());
+
+        $fileInformation = new FileInformation();
+        $fileInfo = $fileInformation->checkFileInformation(
+            $this->upload->reveal(),
+            null,
+            false,
+            true
+        );
+
+        $this->assertEquals($fileInfo, [
+          'filename' => basename($testFile),
+          'file'     => $testFile,
+          'basename' => basename($testFile),
+        ]);
+    }
+
+    public function testFileBasedFileInfoBasic()
+    {
+        $testFile = __DIR__ . '/_files/testsize.mo';
+
+        $fileInformation = new FileInformation();
+        $fileInfo = $fileInformation->checkFileInformation(
+            $testFile
+        );
+
+        $this->assertEquals($fileInfo, [
+          'filename' => basename($testFile),
+          'file'     => $testFile,
+        ]);
+    }
+
+    public function testFileBasedFileInfoBasicWithFiletype()
+    {
+        $testFile = __DIR__ . '/_files/testsize.mo';
+
+        $fileInformation = new FileInformation();
+        $fileInfo = $fileInformation->checkFileInformation(
+            $testFile,
+            null,
+            true
+        );
+
+        $this->assertEquals($fileInfo, [
+          'filename' => basename($testFile),
+          'file'     => $testFile,
+          'filetype' => null
+        ]);
+    }
+
+    public function testFileBasedFileInfoBasicWithBasename()
+    {
+        $testFile = __DIR__ . '/_files/testsize.mo';
+
+        $fileInformation = new FileInformation();
+        $fileInfo = $fileInformation->checkFileInformation(
+            $testFile,
+            null,
+            false,
+            true
+        );
+
+        $this->assertEquals($fileInfo, [
+          'filename' => basename($testFile),
+          'file'     => $testFile,
+          'basename' => basename($testFile)
+        ]);
+    }
+}

--- a/test/File/FileInformationTraitTest.php
+++ b/test/File/FileInformationTraitTest.php
@@ -14,12 +14,9 @@ use Psr\Http\Message\UploadedFileInterface;
 use ZendTest\Validator\File\TestAsset\FileInformation;
 use Zend\Validator\Exception\InvalidArgumentException;
 
-/**
- * @group      Zend_Validator
- */
 class FileInformationTraitTest extends TestCase
 {
-    /** @var ObjectProphecy */
+    /** @var ObjectProphecy|StreamInterface */
     public $stream;
 
     /** @var ObjectProphecy */

--- a/test/File/TestAsset/FileInformation.php
+++ b/test/File/TestAsset/FileInformation.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-validator for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-validator/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Validator\File\TestAsset;
+
+use Zend\Validator\File\FileInformationTrait;
+
+/**
+* Validator which checks if the file already exists in the directory
+*/
+class FileInformation
+{
+    use FileInformationTrait;
+
+    /**
+     * Returns array if the procedure is identified
+     *
+     * @param  string|array|object $value    Filename to check
+     * @param  array               $file     File data from \Zend\File\Transfer\Transfer (optional)
+     * @param  bool                $hasType  Return with filetype (optional)
+     * @param  bool                $basename Return with basename - is calculated from location path (optional)
+     * @return array
+     */
+    public function checkFileInformation(
+        $value,
+        $file = null,
+        $hasType = false,
+        $hasBasename = false
+    ) {
+        return $this->getFileInfo($value, $file, $hasType, $hasBasename);
+    }
+}

--- a/test/File/TestAsset/FileInformation.php
+++ b/test/File/TestAsset/FileInformation.php
@@ -20,14 +20,14 @@ class FileInformation
      * Returns array if the procedure is identified
      *
      * @param  string|array|object $value    Filename to check
-     * @param  array               $file     File data from \Zend\File\Transfer\Transfer (optional)
+     * @param  null|array          $file     File data (when using legacy Zend_File_Transfer API)
      * @param  bool                $hasType  Return with filetype (optional)
      * @param  bool                $basename Return with basename - is calculated from location path (optional)
      * @return array
      */
     public function checkFileInformation(
         $value,
-        $file = null,
+        array $file = null,
         $hasType = false,
         $hasBasename = false
     ) {


### PR DESCRIPTION
This commit allows validation files with `$request->getUploadedFiles()`.

But I got stuck in testing. I want to be able to use a `$upload->getStream()->getMetadata('uri')` and return example `/tmp/abcd`.

```php
$stream = $this->prophesize(StreamInterface::class);
$upload = $this->prophesize(UploadedFileInterface::class);

$stream->getMetadata('uri')->willReturn($testFile);

$upload->getClientFilename()->willReturn('csgo.mo');
$upload->getClientMediaType()->willReturn('mo');
$upload->getError()->willReturn(0);
$upload->getStream()->willReturn($stream->reveal());
$upload->reveal();

$upload->getStream()->getMetadata('uri'); // Call to undefined method Prophecy\Prophecy\MethodProphecy::getMetadata()   
```