### PR TITLE
Fixed a spelling error in Identical validator documentation

### DIFF
--- a/doc/book/validators/identical.md
+++ b/doc/book/validators/identical.md
@@ -206,7 +206,7 @@ this validator with a `Traversable` object.
 
 There is a case which you should be aware of. If you are using an array as
 token, and it contains a `token` key, you should wrap it within another
-`token` key. See the examples below to undestand this situation.
+`token` key. See the examples below to understand this situation.
 
 ```php
 // This will not validate ['token' => 123], it will actually validate the


### PR DESCRIPTION
Following the "Improvement Kata", making small improvements will significantly impact a project positively over time. In this case it's fixing just a typo.