### PR TITLE
fix: Make File\Extension usable for non-existing files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- [#266](https://github.com/zendframework/zend-validator/pull/266) adds a new option to the `File\Extension` and `File\ExcludeExtension` validators, `allowNonExistentFile`. When set to `true`, the validators will continue validating the extension of the filename given even if the file does not exist. The default is `false`, to preserve backwards compatibility with previous versions.
 
 ### Changed
 

--- a/docs/book/validators/file/extension.md
+++ b/docs/book/validators/file/extension.md
@@ -14,6 +14,9 @@ The following set of options are supported:
   against which to test.
 - `case`: Boolean indicating whether or not extensions should match case
   sensitively; defaults to `false` (case-insensitive).
+- `allowNonExistentFile`: (**Since 2.13.0**) Boolean indicating whether or not
+  to allow validating a filename for a non-existent file. Defaults to `false`
+  (will not validate non-existent files).
 
 ## Usage Examples
 

--- a/src/File/ExcludeExtension.php
+++ b/src/File/ExcludeExtension.php
@@ -45,6 +45,16 @@ class ExcludeExtension extends Extension
     {
         $fileInfo = $this->getFileInfo($value, $file);
 
+        // Is file readable ?
+        if (! $this->getAllowNonExistentFile()
+            && (empty($fileInfo['file']) || false === is_readable($fileInfo['file']))
+        ) {
+            if (preg_match('/nofile\.mo$/', $fileInfo['file'])) {
+            }
+            $this->error(self::NOT_FOUND);
+            return false;
+        }
+
         $this->setValue($fileInfo['filename']);
 
         $extension  = substr($fileInfo['filename'], strrpos($fileInfo['filename'], '.') + 1);
@@ -55,6 +65,8 @@ class ExcludeExtension extends Extension
         } elseif (! $this->getCase()) {
             foreach ($extensions as $ext) {
                 if (strtolower($ext) == strtolower($extension)) {
+                    if (preg_match('/nofile\.mo$/', $fileInfo['file'])) {
+                    }
                     $this->error(self::FALSE_EXTENSION);
                     return false;
                 }

--- a/src/File/ExcludeExtension.php
+++ b/src/File/ExcludeExtension.php
@@ -47,12 +47,6 @@ class ExcludeExtension extends Extension
 
         $this->setValue($fileInfo['filename']);
 
-        // Is file readable ?
-        if (empty($fileInfo['file']) || false === is_readable($fileInfo['file'])) {
-            $this->error(self::NOT_FOUND);
-            return false;
-        }
-
         $extension  = substr($fileInfo['filename'], strrpos($fileInfo['filename'], '.') + 1);
         $extensions = $this->getExtension();
 

--- a/src/File/Extension.php
+++ b/src/File/Extension.php
@@ -184,12 +184,6 @@ class Extension extends AbstractValidator
 
         $this->setValue($fileInfo['filename']);
 
-        // Is file readable ?
-        if (empty($fileInfo['file']) || false === is_readable($fileInfo['file'])) {
-            $this->error(self::NOT_FOUND);
-            return false;
-        }
-
         $extension  = substr($fileInfo['filename'], strrpos($fileInfo['filename'], '.') + 1);
         $extensions = $this->getExtension();
 

--- a/src/File/Extension.php
+++ b/src/File/Extension.php
@@ -44,6 +44,7 @@ class Extension extends AbstractValidator
     protected $options = [
         'case'      => false,   // Validate case sensitive
         'extension' => '',      // List of extensions
+        'allowNonExistentFile' => false, // Allow validation even if file does not exist
     ];
 
     /**
@@ -171,6 +172,28 @@ class Extension extends AbstractValidator
     }
 
     /**
+     * Returns whether or not to allow validation of non-existent files.
+     *
+     * @return bool
+     */
+    public function getAllowNonExistentFile()
+    {
+        return $this->options['allowNonExistentFile'];
+    }
+
+    /**
+     * Sets the flag indicating whether or not to allow validation of non-existent files.
+     *
+     * @param  bool $flag Whether or not to allow validation of non-existent files.
+     * @return self Provides a fluent interface
+     */
+    public function setAllowNonExistentFile($flag)
+    {
+        $this->options['allowNonExistentFile'] = (bool) $flag;
+        return $this;
+    }
+
+    /**
      * Returns true if and only if the file extension of $value is included in the
      * set extension list
      *
@@ -181,6 +204,14 @@ class Extension extends AbstractValidator
     public function isValid($value, $file = null)
     {
         $fileInfo = $this->getFileInfo($value, $file);
+
+        // Is file readable ?
+        if (! $this->getAllowNonExistentFile()
+            && (empty($fileInfo['file']) || false === is_readable($fileInfo['file']))
+        ) {
+            $this->error(self::NOT_FOUND);
+            return false;
+        }
 
         $this->setValue($fileInfo['filename']);
 

--- a/test/File/ExcludeExtensionTest.php
+++ b/test/File/ExcludeExtensionTest.php
@@ -38,6 +38,7 @@ class ExcludeExtensionTest extends TestCase
         $noFileTests = [
             //    Options, isValid Param, Expected value, message
             ['mo', $testFile, false, 'fileExcludeExtensionNotFound'],
+            [['extension' => 'gif', 'allowNonExistentFile' => true], $testFile, true, ''],
         ];
 
         // Dupe data in File Upload format

--- a/test/File/ExtensionTest.php
+++ b/test/File/ExtensionTest.php
@@ -38,6 +38,7 @@ class ExtensionTest extends TestCase
         $noFileTests = [
             //    Options, isValid Param, Expected value, message
             ['mo', $testFile, false, 'fileExtensionNotFound'],
+            [['extension' => 'mo', 'allowNonExistentFile' => true], $testFile, true, ''],
         ];
 
         // Dupe data in File Upload format
@@ -49,6 +50,8 @@ class ExtensionTest extends TestCase
             ];
             $testData[] = [$data[0], $fileUpload, $data[2], $data[3]];
         }
+
+
         return $testData;
     }
 


### PR DESCRIPTION
Currently the validator fails if the given filename is not readable. This prevents valid use cases like checking if a user configurable filename has an allowed file extension before creating said file.

As the validator only operates on the given string there is no need for the current readable check.

Also fixes File\ExcludeExtension which suffers from the same issue.

In theory it's a BC breaking change, personally I would consider any code that (ab)uses this validator as a file_is_readable validator to be smelly/buggy.