### PR TITLE
Lowercase composer dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "container-interop/container-interop": "^1.1"
     },
     "require-dev": {
-        "phpunit/PHPUnit": "^6.0.8 || ^5.7.15",
+        "phpunit/phpunit": "^6.0.8 || ^5.7.15",
         "psr/http-message": "^1.0",
         "zendframework/zend-cache": "^2.6.1",
         "zendframework/zend-coding-standard": "~1.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d63c66fe8848c902d47f6175d0d73710",
+    "content-hash": "b111c3e3e3eed8692208b6748d67742f",
     "packages": [
         {
             "name": "container-interop/container-interop",


### PR DESCRIPTION
Uppercase characters in package name are deprecated and will error in Composer 2.0