### PR TITLE
Fix: replace curly offset access brace with square brackets

### DIFF
--- a/src/Isbn/Isbn10.php
+++ b/src/Isbn/Isbn10.php
@@ -32,7 +32,7 @@ class Isbn10
         $sum = 0;
 
         for ($i = 0; $i < 9; $i++) {
-            $sum += (10 - $i) * $value{$i};
+            $sum += (10 - $i) * $value[$i];
         }
 
         return $sum;

--- a/src/Isbn/Isbn13.php
+++ b/src/Isbn/Isbn13.php
@@ -33,11 +33,11 @@ class Isbn13
 
         for ($i = 0; $i < 12; $i++) {
             if ($i % 2 == 0) {
-                $sum += $value{$i};
+                $sum += $value[$i];
                 continue;
             }
 
-            $sum += 3 * $value{$i};
+            $sum += 3 * $value[$i];
         }
 
         return $sum;


### PR DESCRIPTION
As of PHP 7.4:
the array and string offset access syntax using curly braces is deprecated.