### PR TITLE
Strict mode for Date validator

### DIFF
--- a/docs/book/validators/date.md
+++ b/docs/book/validators/date.md
@@ -33,3 +33,24 @@ $validator = new Zend\Validator\Date(['format' => 'Y']);
 $validator->isValid('2010'); // returns true
 $validator->isValid('May');  // returns false
 ```
+
+## Strict mode
+
+- **Since 2.13.0**
+
+By default, `Zend\Validator\Date` only validates that it can convert the
+provided value to a valid `DateTime` value.
+
+If you want to require that the date is specified in a specific format, you can
+provide both the [date format](#specifying-a-date-format) and the `strict`
+options. In such a scenario, the value must both be covertable to a `DateTime`
+value **and** be in the same format as provided to the validator. (Generally,
+this will mean the value must be a string.)
+
+```php
+$validator = new Zend\Validator\Date(['format' => 'Y-m-d', 'strict' => true]);
+
+$validator->isValid('2010-10-10'); // returns true
+$validator->isValid(new DateTime('2010-10-10)); // returns false; value is not a string
+$validator->isValid('2010.10.10'); // returns false; format differs
+```

--- a/src/Date.php
+++ b/src/Date.php
@@ -3,7 +3,7 @@
  * Zend Framework (http://framework.zend.com/)
  *
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2005-2019 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
@@ -105,28 +105,13 @@ class Date extends AbstractValidator
         return $this;
     }
 
-    /**
-     * @param bool $strict
-     * @return $this
-     */
-    public function setStrict($strict)
+    public function setStrict(bool $strict) : self
     {
-        if (! is_bool($strict)) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                'Expected boolean value; %s received',
-                is_object($strict) ? get_class($strict) : gettype($strict)
-            ));
-        }
-
         $this->strict = $strict;
-
         return $this;
     }
 
-    /**
-     * @return bool
-     */
-    public function isStrict()
+    public function isStrict() : bool
     {
         return $this->strict;
     }

--- a/src/Date.php
+++ b/src/Date.php
@@ -57,6 +57,11 @@ class Date extends AbstractValidator
     protected $format = self::FORMAT_DEFAULT;
 
     /**
+     * @var bool
+     */
+    protected $strict = false;
+
+    /**
      * Sets validator options
      *
      * @param  string|array|Traversable $options OPTIONAL
@@ -101,6 +106,32 @@ class Date extends AbstractValidator
     }
 
     /**
+     * @param bool $strict
+     * @return $this
+     */
+    public function setStrict($strict)
+    {
+        if (! is_bool($strict)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Expected boolean value; %s received',
+                is_object($strict) ? get_class($strict) : gettype($strict)
+            ));
+        }
+
+        $this->strict = $strict;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isStrict()
+    {
+        return $this->strict;
+    }
+
+    /**
      * Returns true if $value is a DateTime instance or can be converted into one.
      *
      * @param  string|array|int|DateTime $value
@@ -110,8 +141,14 @@ class Date extends AbstractValidator
     {
         $this->setValue($value);
 
-        if (! $this->convertToDateTime($value)) {
+        $date = $this->convertToDateTime($value);
+        if (! $date) {
             $this->error(self::INVALID_DATE);
+            return false;
+        }
+
+        if ($this->isStrict() && $date->format($this->getFormat()) !== $value) {
+            $this->error(self::FALSEFORMAT);
             return false;
         }
 

--- a/test/DateTest.php
+++ b/test/DateTest.php
@@ -44,48 +44,53 @@ class DateTest extends TestCase
     public function datesDataProvider()
     {
         return [
-            //    date                       format             isValid
-            ['2007-01-01',              null,              true],
-            ['2007-02-28',              null,              true],
-            ['2007-02-29',              null,              false],
-            ['2008-02-29',              null,              true],
-            ['2007-02-30',              null,              false],
-            ['2007-02-99',              null,              false],
-            ['2007-02-99',              'Y-m-d',           false],
-            ['9999-99-99',              null,              false],
-            ['9999-99-99',              'Y-m-d',           false],
-            ['Jan 1 2007',              null,              false],
-            ['Jan 1 2007',              'M j Y',           true],
-            ['asdasda',                 null,              false],
-            ['sdgsdg',                  null,              false],
-            ['2007-01-01something',     null,              false],
-            ['something2007-01-01',     null,              false],
-            ['10.01.2008',              'd.m.Y',           true],
-            ['01 2010',                 'm Y',             true],
-            ['2008/10/22',              'd/m/Y',           false],
-            ['22/10/08',                'd/m/y',           true],
-            ['22/10',                   'd/m/Y',           false],
+            // date                     format             isValid   isValid Strict
+            ['2007-01-01',              null,              true,     true],
+            ['2007-02-28',              null,              true,     true],
+            ['2007-02-29',              null,              false,    false],
+            ['2008-02-29',              null,              true,     true],
+            ['2007-02-30',              null,              false,    false],
+            ['2007-02-99',              null,              false,    false],
+            ['2007-02-99',              'Y-m-d',           false,    false],
+            ['9999-99-99',              null,              false,    false],
+            ['9999-99-99',              'Y-m-d',           false,    false],
+            ['Jan 1 2007',              null,              false,    false],
+            ['Jan 1 2007',              'M j Y',           true,     true],
+            ['asdasda',                 null,              false,    false],
+            ['sdgsdg',                  null,              false,    false],
+            ['2007-01-01something',     null,              false,    false],
+            ['something2007-01-01',     null,              false,    false],
+            ['10.01.2008',              'd.m.Y',           true,     true],
+            ['01 2010',                 'm Y',             true,     true],
+            ['2008/10/22',              'd/m/Y',           false,    false],
+            ['22/10/08',                'd/m/y',           true,     true],
+            ['22/10',                   'd/m/Y',           false,    false],
             // time
-            ['2007-01-01T12:02:55Z',    DateTime::ISO8601, true],
-            ['12:02:55',                'H:i:s',           true],
-            ['25:02:55',                'H:i:s',           false],
+            ['2007-01-01T12:02:55Z',    DateTime::ISO8601, true,     false],
+            ['2007-01-01T12:02:55+0000', DateTime::ISO8601, true,    true],
+            ['12:02:55',                'H:i:s',           true,     true],
+            ['25:02:55',                'H:i:s',           false,    false],
             // int
-            [0,                         null,              true],
-            [1340677235,                null,              true],
+            [0,                         null,              true,     false],
+            [6,                         'd',               true,     false],
+            ['6',                       'd',               true,     false],
+            ['06',                      'd',               true,     true],
+            [123,                       null,              true,     false],
+            [1340677235,                null,              true,     false],
             // 32bit version of php will convert this to double
-            [999999999999,              null,              true],
+            [999999999999,              null,              true,     false],
             // double
-            [12.12,                     null,              false],
+            [12.12,                     null,              false,    false],
             // array
-            [['2012', '06', '25'], null,              true],
+            [['2012', '06', '25'],      null,              true,     false],
             // 0012-06-25 is a valid date, if you want 2012, use 'y' instead of 'Y'
-            [['12', '06', '25'],   null,              true],
-            [['2012', '06', '33'], null,              false],
-            [[1 => 1],             null,              false],
+            [['12', '06', '25'],        null,              true,     false],
+            [['2012', '06', '33'],      null,              false,    false],
+            [[1 => 1],                  null,              false,    false],
             // DateTime
-            [new DateTime(),            null,              true],
+            [new DateTime(),            null,              true,     false],
             // invalid obj
-            [new stdClass(),           null,              false],
+            [new stdClass(),            null,              false,    false],
         ];
     }
 
@@ -98,6 +103,21 @@ class DateTest extends TestCase
     {
         $this->validator->setFormat($format);
         $this->assertEquals($result, $this->validator->isValid($input));
+    }
+
+    /**
+     * @dataProvider datesDataProvider
+     *
+     * @param mixed $input
+     * @param string|null $format
+     * @param bool $result
+     * @param bool $resultStrict
+     */
+    public function testBasicStrictMode($input, $format, $result, $resultStrict)
+    {
+        $this->validator->setStrict(true);
+        $this->validator->setFormat($format);
+        $this->assertSame($resultStrict, $this->validator->isValid($input));
     }
 
     public function testDateTimeImmutable()

--- a/test/DateTest.php
+++ b/test/DateTest.php
@@ -77,6 +77,8 @@ class DateTest extends TestCase
             ['06',                      'd',               true,     true],
             [123,                       null,              true,     false],
             [1340677235,                null,              true,     false],
+            [1340677235,                'U',               true,     false],
+            ['1340677235',              'U',               true,     true],
             // 32bit version of php will convert this to double
             [999999999999,              null,              true,     false],
             // double

--- a/test/DateTest.php
+++ b/test/DateTest.php
@@ -3,7 +3,7 @@
  * Zend Framework (http://framework.zend.com/)
  *
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2005-2019 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
@@ -111,11 +111,8 @@ class DateTest extends TestCase
      * @dataProvider datesDataProvider
      *
      * @param mixed $input
-     * @param string|null $format
-     * @param bool $result
-     * @param bool $resultStrict
      */
-    public function testBasicStrictMode($input, $format, $result, $resultStrict)
+    public function testBasicStrictMode($input, ?string $format, bool $result, bool $resultStrict) : void
     {
         $this->validator->setStrict(true);
         $this->validator->setFormat($format);


### PR DESCRIPTION
Input must be always in the defined format and must be the same as output
of format method of DateTime.

Strict mode is set to `false` by default to keep BC.

Currently to the validator we can provide `integer`, `double`, `array`, `string` or `DateTimeInterface` value. In my opinion as validator has set format we should check if the input value has exactly the same format as set.
In strict mode we are comparing if:
```php
$input === DateTime::createFromFormat($format, $input)->format($format);
```

Resolve #33
Fix zendframework/zendframework#6407

- [x] Are you creating a new feature?
  - [x] Why is the new feature needed? What purpose does it serve?
  - [x] How will users use the new feature?
  - [x] Base your feature on the `develop` branch, and submit against that branch.
  - [x] Add only one feature per pull request; split multiple features over multiple pull requests
  - [x] Add tests for the new feature.
  - [ ] Add documentation for the new feature.
  - [ ] Add a `CHANGELOG.md` entry for the new feature.

I would see strict mode by default enabled in v3, or ONLY strict mode in v3.
Thoughts?

/cc @svycka @gianarb 
